### PR TITLE
feat: Auto login and redirect

### DIFF
--- a/__tests__/contexts/auth-context-test.tsx
+++ b/__tests__/contexts/auth-context-test.tsx
@@ -1,0 +1,508 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('@/lib/api/client', () => ({
+  setAuthToken: jest.fn(),
+  setBaseUrl: jest.fn(),
+  setOnSessionExpired: jest.fn(),
+  setOnAuthRefreshed: jest.fn(),
+}));
+
+jest.mock('@/lib/api/auth', () => ({
+  login: jest.fn(),
+}));
+
+import React, { useCallback } from 'react';
+import { Text, Pressable } from 'react-native';
+import { render, waitFor, fireEvent, act } from '@testing-library/react-native';
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AuthProvider, useAuth } from '@/contexts/auth-context';
+import { setAuthToken, setBaseUrl } from '@/lib/api/client';
+import { login } from '@/lib/api/auth';
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+const mockLogin = login as jest.Mock;
+
+// Interactive consumer that exposes context state and actions
+function TestConsumer() {
+  const auth = useAuth();
+
+  const handleSetAuth = useCallback(async () => {
+    await auth.setAuth(
+      'new-token',
+      { id: 1, username: 'alice', role: 'user', permissions: {} },
+      Date.now() + 86400000,
+    );
+  }, [auth]);
+
+  const handleSaveCredentials = useCallback(async () => {
+    await auth.saveCredentials('alice', 'pass123');
+  }, [auth]);
+
+  const handleRememberOn = useCallback(async () => {
+    await auth.setRememberCredentials(true);
+  }, [auth]);
+
+  const handleRememberOff = useCallback(async () => {
+    await auth.setRememberCredentials(false);
+  }, [auth]);
+
+  const handleBiometricsOn = useCallback(async () => {
+    await auth.setUseBiometrics(true);
+  }, [auth]);
+
+  const handleBiometricsOff = useCallback(async () => {
+    await auth.setUseBiometrics(false);
+  }, [auth]);
+
+  const handleClearAll = useCallback(async () => {
+    await auth.clearAll();
+  }, [auth]);
+
+  return (
+    <>
+      <Text testID="token">{auth.token ?? 'null'}</Text>
+      <Text testID="serverUrl">{auth.serverUrl ?? 'null'}</Text>
+      <Text testID="user">{auth.user?.username ?? 'null'}</Text>
+      <Text testID="sessionExpired">{String(auth.sessionExpired)}</Text>
+      <Text testID="rememberCredentials">{String(auth.rememberCredentials)}</Text>
+      <Text testID="useBiometrics">{String(auth.useBiometrics)}</Text>
+      <Text testID="hasCredentials">{String(auth.hasCredentials)}</Text>
+      <Pressable testID="setAuth" onPress={handleSetAuth} />
+      <Pressable testID="saveCredentials" onPress={handleSaveCredentials} />
+      <Pressable testID="rememberOn" onPress={handleRememberOn} />
+      <Pressable testID="rememberOff" onPress={handleRememberOff} />
+      <Pressable testID="biometricsOn" onPress={handleBiometricsOn} />
+      <Pressable testID="biometricsOff" onPress={handleBiometricsOff} />
+      <Pressable testID="clearAll" onPress={handleClearAll} />
+    </>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <AuthProvider>
+      <TestConsumer />
+    </AuthProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  mockSecureStore.getItemAsync.mockResolvedValue(null);
+  mockAsyncStorage.getItem.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('AuthProvider — restore on mount', () => {
+  it('restores token, user, and server URL', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'my-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('my-token');
+      expect(getByTestId('serverUrl').props.children).toBe('https://my-server.com');
+      expect(getByTestId('user').props.children).toBe('alice');
+    });
+
+    expect(setBaseUrl).toHaveBeenCalledWith('https://my-server.com');
+    expect(setAuthToken).toHaveBeenCalledWith('my-token');
+  });
+
+  it('starts with null state when nothing stored', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId('serverUrl').props.children).toBe('null');
+    });
+  });
+});
+
+describe('AuthProvider — 30-day inactivity hard expire', () => {
+  const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1000;
+
+  it('clears all data when inactive for more than 30 days', async () => {
+    const oldTimestamp = String(Date.now() - THIRTY_ONE_DAYS_MS);
+
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'old-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === 'last_active_at') return oldTimestamp;
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId('serverUrl').props.children).toBe('null');
+      expect(getByTestId('user').props.children).toBe('null');
+    });
+
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_token');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('user_json');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('remember_credentials');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('use_biometrics');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('last_active_at');
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('server_url');
+  });
+
+  it('restores normally when active within 30 days', async () => {
+    const recentTimestamp = String(Date.now() - 5 * 24 * 60 * 60 * 1000);
+
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'valid-token';
+      if (key === 'user_json') return '{"id":1,"username":"bob","role":"admin"}';
+      if (key === 'last_active_at') return recentTimestamp;
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('valid-token');
+      expect(getByTestId('user').props.children).toBe('bob');
+    });
+
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('restores normally when lastActiveAt is not set (fresh install)', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'fresh-token';
+      if (key === 'user_json') return '{"id":1,"username":"carol","role":"user"}';
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('fresh-token');
+      expect(getByTestId('user').props.children).toBe('carol');
+    });
+  });
+});
+
+describe('AuthProvider — setAuth bumps lastActiveAt', () => {
+  it('writes lastActiveAt to storage on setAuth', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('setAuth'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('new-token');
+    });
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'last_active_at',
+      expect.stringMatching(/^\d+$/),
+    );
+  });
+});
+
+describe('AuthProvider — credential clearing logic', () => {
+  it('does not clear credentials when turning off remember if biometrics is on', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    // Enable biometrics first, then remember
+    await act(async () => {
+      fireEvent.press(getByTestId('biometricsOn'));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOn'));
+    });
+
+    jest.clearAllMocks();
+
+    // Turn off remember — credentials should NOT be deleted because biometrics is still on
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOff'));
+    });
+
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_password');
+  });
+
+  it('does not clear credentials when turning off biometrics if remember is on', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOn'));
+    });
+    await act(async () => {
+      fireEvent.press(getByTestId('biometricsOn'));
+    });
+
+    jest.clearAllMocks();
+
+    // Turn off biometrics — credentials should NOT be deleted because remember is still on
+    await act(async () => {
+      fireEvent.press(getByTestId('biometricsOff'));
+    });
+
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_password');
+  });
+
+  it('clears credentials when both remember and biometrics are off', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    // Enable remember, then turn it off (biometrics already off)
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOn'));
+    });
+
+    jest.clearAllMocks();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOff'));
+    });
+
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
+  });
+});
+
+describe('AuthProvider — saveCredentials conditional', () => {
+  it('does not save when neither remember nor biometrics is enabled', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('rememberCredentials').props.children).toBe('false');
+      expect(getByTestId('useBiometrics').props.children).toBe('false');
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('saveCredentials'));
+    });
+
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith('saved_username', 'alice');
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith('saved_password', 'pass123');
+  });
+
+  it('saves when remember is enabled', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('rememberOn'));
+    });
+
+    jest.clearAllMocks();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('saveCredentials'));
+    });
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_username', 'alice');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_password', 'pass123');
+  });
+
+  it('saves when biometrics is enabled (even without remember)', async () => {
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('biometricsOn'));
+    });
+
+    jest.clearAllMocks();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('saveCredentials'));
+    });
+
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_username', 'alice');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_password', 'pass123');
+  });
+});
+
+describe('AuthProvider — clearAll', () => {
+  it('clears all state and storage including lastActiveAt', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'my-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('my-token');
+    });
+
+    jest.clearAllMocks();
+
+    await act(async () => {
+      fireEvent.press(getByTestId('clearAll'));
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId('serverUrl').props.children).toBe('null');
+      expect(getByTestId('user').props.children).toBe('null');
+    });
+
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('last_active_at');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('server_url');
+  });
+});
+
+describe('AuthProvider — proactive expiry timer', () => {
+  it('triggers sessionExpired when token expires and no remember', async () => {
+    const expiresIn = 120_000; // 2 minutes from now
+    const expiresAt = String(Date.now() + expiresIn);
+
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'my-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === 'token_expires_at') return expiresAt;
+      if (key === 'remember_credentials') return null;
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('my-token');
+      expect(getByTestId('sessionExpired').props.children).toBe('false');
+    });
+
+    // Timer fires 60s before expiry, so at expiresIn - 60000 = 60000ms
+    await act(async () => {
+      jest.advanceTimersByTime(expiresIn);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('sessionExpired').props.children).toBe('true');
+    });
+  });
+
+  it('silently re-auths when token expires and remember is on', async () => {
+    // Use real timers for this test since the timer callback has async/await
+    jest.useRealTimers();
+
+    // 61s from now — timer fires at expiresIn - 60s = 1s
+    const expiresIn = 61_000;
+    const expiresAt = String(Date.now() + expiresIn);
+    const newExpiresAt = Date.now() + expiresIn + 86400000;
+
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'my-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === 'token_expires_at') return expiresAt;
+      if (key === 'remember_credentials') return 'true';
+      if (key === 'saved_username') return 'alice';
+      if (key === 'saved_password') return 'pass123';
+      return null;
+    });
+
+    mockLogin.mockResolvedValue({
+      token: 'renewed-token',
+      expiresAt: newExpiresAt,
+      user: { id: 1, username: 'alice', role: 'user' },
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('my-token');
+    });
+
+    // Timer fires at ~1s (61s - 60s buffer). Wait for re-auth to complete.
+    await waitFor(
+      () => {
+        expect(getByTestId('sessionExpired').props.children).toBe('false');
+        expect(getByTestId('token').props.children).toBe('renewed-token');
+      },
+      { timeout: 5000 },
+    );
+
+    jest.useFakeTimers();
+  });
+
+  it('fires immediately when token is already expired on restore', async () => {
+    const expiredAt = String(Date.now() - 60_000); // expired 1 minute ago
+
+    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'auth_token') return 'expired-token';
+      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === 'token_expires_at') return expiredAt;
+      if (key === 'remember_credentials') return null;
+      return null;
+    });
+
+    const { getByTestId } = renderWithProvider();
+
+    await waitFor(() => {
+      expect(getByTestId('token').props.children).toBe('expired-token');
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(0);
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('sessionExpired').props.children).toBe('true');
+    });
+  });
+});

--- a/__tests__/lib/api/client-interceptor-test.ts
+++ b/__tests__/lib/api/client-interceptor-test.ts
@@ -1,0 +1,269 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+jest.mock('axios', () => {
+  const requestHandlers: any[] = [];
+  const responseHandlers: any[] = [];
+
+  const interceptors = {
+    request: {
+      handlers: requestHandlers,
+      use: jest.fn((fulfilled, rejected) => {
+        requestHandlers.push({ fulfilled, rejected });
+        return requestHandlers.length - 1;
+      }),
+    },
+    response: {
+      handlers: responseHandlers,
+      use: jest.fn((fulfilled, rejected) => {
+        responseHandlers.push({ fulfilled, rejected });
+        return responseHandlers.length - 1;
+      }),
+    },
+  };
+
+  const instance = {
+    defaults: { baseURL: 'https://test.com/api', headers: { 'Content-Type': 'application/json' } },
+    interceptors,
+    get: jest.fn(),
+    post: jest.fn(),
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(() => instance),
+      post: jest.fn(),
+    },
+    AxiosError: class AxiosError extends Error {
+      code?: string;
+      response?: any;
+      config?: any;
+    },
+  };
+});
+
+import axios from 'axios';
+import * as SecureStore from 'expo-secure-store';
+import {
+  ApiError,
+  api,
+  setAuthToken,
+  setOnSessionExpired,
+  setOnAuthRefreshed,
+} from '@/lib/api/client';
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+function getResponseErrorHandler() {
+  const handlers = (api.interceptors.response as any).handlers;
+  return handlers[handlers.length - 1]?.rejected;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setAuthToken(null);
+  setOnSessionExpired(null);
+  setOnAuthRefreshed(null);
+});
+
+describe('response interceptor — real 401', () => {
+  it('calls onSessionExpired when no saved credentials', async () => {
+    const onExpired = jest.fn();
+    setOnSessionExpired(onExpired);
+    setAuthToken('valid-token');
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: { status: 401, data: { message: 'Authentication required' } },
+      config: { headers: {} },
+      code: undefined,
+    };
+
+    await expect(handler(error)).rejects.toThrow(ApiError);
+    expect(onExpired).toHaveBeenCalled();
+  });
+
+  it('attempts silent re-auth when remember is on', async () => {
+    setAuthToken('expired-token');
+
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'remember_credentials') return 'true';
+      if (key === 'saved_username') return 'alice';
+      if (key === 'saved_password') return 'pass123';
+      return null;
+    });
+
+    const expiresAt = Date.now() + 86400000;
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        token: 'new-token',
+        expiresAt,
+        user: { id: 1, username: 'alice', role: 'user' },
+      },
+    });
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: { status: 401, data: { message: 'Auth required' } },
+      config: { headers: {} },
+      code: undefined,
+    };
+
+    try {
+      await handler(error);
+    } catch {
+      // retry call may fail — we verify login was attempted
+    }
+
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://test.com/api/auth/login',
+      { username: 'alice', password: 'pass123' },
+      expect.any(Object),
+    );
+  });
+
+  it('does not retry already-retried requests', async () => {
+    const onExpired = jest.fn();
+    setOnSessionExpired(onExpired);
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: { status: 401, data: { message: 'Auth required' } },
+      config: { headers: {}, _retried: true },
+      code: undefined,
+    };
+
+    await expect(handler(error)).rejects.toThrow(ApiError);
+    expect(onExpired).not.toHaveBeenCalled();
+  });
+});
+
+describe('response interceptor — iOS timeout fallback', () => {
+  it('treats ECONNABORTED as session expiry when authenticated', async () => {
+    const onExpired = jest.fn();
+    setOnSessionExpired(onExpired);
+    setAuthToken('some-token');
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: undefined,
+      config: { headers: {} },
+      code: 'ECONNABORTED',
+    };
+
+    await expect(handler(error)).rejects.toThrow(ApiError);
+    expect(onExpired).toHaveBeenCalled();
+  });
+
+  it('does not treat timeout as session expiry when not authenticated', async () => {
+    setAuthToken(null);
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: undefined,
+      config: { headers: {} },
+      code: 'ECONNABORTED',
+    };
+
+    await expect(handler(error)).rejects.toThrow('Unable to reach server');
+  });
+
+  it('does not treat non-timeout network errors as session expiry', async () => {
+    setAuthToken('some-token');
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: undefined,
+      config: { headers: {} },
+      code: 'ERR_NETWORK',
+    };
+
+    await expect(handler(error)).rejects.toThrow('Unable to reach server');
+  });
+});
+
+describe('response interceptor — non-401 errors', () => {
+  it('throws ApiError with correct status for 500', async () => {
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: { status: 500, data: { error: 'Internal server error' } },
+      config: { headers: {} },
+    };
+
+    try {
+      await handler(error);
+      fail('should have thrown');
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect(e.status).toBe(500);
+      expect(e.message).toBe('Internal server error');
+    }
+  });
+
+  it('throws network error when no response and no timeout', async () => {
+    setAuthToken(null);
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: undefined,
+      config: { headers: {} },
+      code: undefined,
+    };
+
+    await expect(handler(error)).rejects.toThrow('Unable to reach server');
+  });
+});
+
+describe('setOnAuthRefreshed', () => {
+  it('is called with token, userJson and expiresAt after silent re-auth', async () => {
+    const onRefreshed = jest.fn();
+    setOnAuthRefreshed(onRefreshed);
+    setAuthToken('expired');
+
+    mockSecureStore.getItemAsync.mockImplementation(async (key) => {
+      if (key === 'remember_credentials') return 'true';
+      if (key === 'saved_username') return 'bob';
+      if (key === 'saved_password') return 'secret';
+      return null;
+    });
+
+    const expiresAt = Date.now() + 86400000;
+    (axios.post as jest.Mock).mockResolvedValue({
+      data: {
+        token: 'fresh-token',
+        expiresAt,
+        user: { id: 2, username: 'bob', role: 'admin' },
+      },
+    });
+
+    const handler = getResponseErrorHandler();
+    const error = {
+      response: { status: 401, data: { message: 'Auth required' } },
+      config: { headers: {} },
+      code: undefined,
+    };
+
+    try {
+      await handler(error);
+    } catch {
+      // retry may throw
+    }
+
+    expect(onRefreshed).toHaveBeenCalledWith(
+      'fresh-token',
+      JSON.stringify({ id: 2, username: 'bob', role: 'admin' }),
+      expiresAt,
+    );
+  });
+});

--- a/__tests__/lib/api/client-test.ts
+++ b/__tests__/lib/api/client-test.ts
@@ -1,3 +1,15 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
 jest.mock('axios', () => {
   const interceptors = {
     request: { handlers: [] as any[], use: jest.fn() },

--- a/__tests__/lib/api/library-test.ts
+++ b/__tests__/lib/api/library-test.ts
@@ -1,3 +1,15 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
 jest.mock('axios', () => {
   const instance = {
     defaults: { baseURL: '', headers: {} },

--- a/__tests__/lib/storage-credentials-test.ts
+++ b/__tests__/lib/storage-credentials-test.ts
@@ -136,3 +136,33 @@ describe('SecureStorage.expiresAt', () => {
     expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
   });
 });
+
+describe('SecureStorage.lastActiveAt', () => {
+  it('gets last active timestamp', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('1700000000000');
+    expect(await SecureStorage.getLastActiveAt()).toBe(1700000000000);
+  });
+
+  it('returns null when not stored', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    expect(await SecureStorage.getLastActiveAt()).toBeNull();
+  });
+
+  it('returns null on error', async () => {
+    mockSecureStore.getItemAsync.mockRejectedValue(new Error('fail'));
+    expect(await SecureStorage.getLastActiveAt()).toBeNull();
+  });
+
+  it('sets last active timestamp', async () => {
+    await SecureStorage.setLastActiveAt(1700000000000);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'last_active_at',
+      '1700000000000',
+    );
+  });
+
+  it('deletes last active timestamp', async () => {
+    await SecureStorage.deleteLastActiveAt();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('last_active_at');
+  });
+});

--- a/__tests__/lib/storage-credentials-test.ts
+++ b/__tests__/lib/storage-credentials-test.ts
@@ -1,0 +1,138 @@
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { SecureStorage } from '@/lib/storage';
+
+const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('SecureStorage.credentials', () => {
+  it('gets credentials when both exist', async () => {
+    mockSecureStore.getItemAsync
+      .mockResolvedValueOnce('alice')
+      .mockResolvedValueOnce('pass123');
+    const result = await SecureStorage.getCredentials();
+    expect(result).toEqual({ username: 'alice', password: 'pass123' });
+  });
+
+  it('returns null when username missing', async () => {
+    mockSecureStore.getItemAsync
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('pass123');
+    expect(await SecureStorage.getCredentials()).toBeNull();
+  });
+
+  it('returns null when password missing', async () => {
+    mockSecureStore.getItemAsync
+      .mockResolvedValueOnce('alice')
+      .mockResolvedValueOnce(null);
+    expect(await SecureStorage.getCredentials()).toBeNull();
+  });
+
+  it('returns null on error', async () => {
+    mockSecureStore.getItemAsync.mockRejectedValue(new Error('fail'));
+    expect(await SecureStorage.getCredentials()).toBeNull();
+  });
+
+  it('sets credentials', async () => {
+    await SecureStorage.setCredentials('alice', 'pass123');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_username', 'alice');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_password', 'pass123');
+  });
+
+  it('deletes credentials', async () => {
+    await SecureStorage.deleteCredentials();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
+  });
+});
+
+describe('SecureStorage.rememberCredentials', () => {
+  it('returns true when stored as "true"', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('true');
+    expect(await SecureStorage.getRememberCredentials()).toBe(true);
+  });
+
+  it('returns false when stored as "false"', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('false');
+    expect(await SecureStorage.getRememberCredentials()).toBe(false);
+  });
+
+  it('returns false when not stored', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    expect(await SecureStorage.getRememberCredentials()).toBe(false);
+  });
+
+  it('sets remember credentials', async () => {
+    await SecureStorage.setRememberCredentials(true);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('remember_credentials', 'true');
+  });
+
+  it('deletes remember credentials', async () => {
+    await SecureStorage.deleteRememberCredentials();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('remember_credentials');
+  });
+});
+
+describe('SecureStorage.useBiometrics', () => {
+  it('returns true when stored as "true"', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('true');
+    expect(await SecureStorage.getUseBiometrics()).toBe(true);
+  });
+
+  it('returns false when not stored', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    expect(await SecureStorage.getUseBiometrics()).toBe(false);
+  });
+
+  it('sets biometrics preference', async () => {
+    await SecureStorage.setUseBiometrics(true);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('use_biometrics', 'true');
+  });
+
+  it('deletes biometrics preference', async () => {
+    await SecureStorage.deleteUseBiometrics();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('use_biometrics');
+  });
+});
+
+describe('SecureStorage.expiresAt', () => {
+  it('gets expiry timestamp', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue('1700000000000');
+    expect(await SecureStorage.getExpiresAt()).toBe(1700000000000);
+  });
+
+  it('returns null when not stored', async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    expect(await SecureStorage.getExpiresAt()).toBeNull();
+  });
+
+  it('returns null on error', async () => {
+    mockSecureStore.getItemAsync.mockRejectedValue(new Error('fail'));
+    expect(await SecureStorage.getExpiresAt()).toBeNull();
+  });
+
+  it('sets expiry timestamp', async () => {
+    await SecureStorage.setExpiresAt(1700000000000);
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      'token_expires_at',
+      '1700000000000',
+    );
+  });
+
+  it('deletes expiry timestamp', async () => {
+    await SecureStorage.deleteExpiresAt();
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
+  });
+});

--- a/app.json
+++ b/app.json
@@ -12,7 +12,8 @@
       "bundleIdentifier": "com.aurral.aurralpocket",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false
-      }
+      },
+      "appleTeamId": "7538KXR6QZ"
     },
     "android": {
       "adaptiveIcon": {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,9 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
+  Alert,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   View,
 } from 'react-native';
 import * as Haptics from 'expo-haptics';
@@ -13,6 +16,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { useAuth } from '@/contexts/auth-context';
 import { useLogin } from '@/hooks/auth/use-login';
+import { useBiometricAvailability } from '@/hooks/auth/use-biometric-availability';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { Colors } from '@/constants/theme';
 import { ApiError } from '@/lib/api/client';
@@ -28,20 +32,79 @@ function getErrorMessage(error: Error | null): string | null {
   return error.message;
 }
 
+function showRememberWarning(onConfirm: () => void) {
+  Alert.alert(
+    'Store Credentials',
+    'Your password will be saved in encrypted storage on this device so you can be automatically signed back in when your session expires.',
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Enable', onPress: onConfirm },
+    ],
+  );
+}
+
+function showBiometricWarning(onConfirm: () => void, label: string) {
+  Alert.alert(
+    'Store Credentials',
+    `Your password will be saved in encrypted storage on this device so you can use ${label} to sign back in when your session expires.`,
+    [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Enable', onPress: onConfirm },
+    ],
+  );
+}
+
 export default function LoginScreen() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme];
-  const { serverUrl, clearAll } = useAuth();
+  const {
+    serverUrl,
+    clearAll,
+    rememberCredentials,
+    useBiometrics,
+    setRememberCredentials,
+    setUseBiometrics,
+    saveCredentials,
+  } = useAuth();
   const loginMutation = useLogin();
+  const biometricLabel = useBiometricAvailability();
 
   const handleLogin = () => {
     if (!username.trim() || !password) {
       return;
     }
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    loginMutation.mutate({ username: username.trim(), password });
+    loginMutation.mutate(
+      { username: username.trim(), password },
+      {
+        onSuccess: () => {
+          if (rememberCredentials || useBiometrics) {
+            saveCredentials(username.trim(), password);
+          }
+        },
+      },
+    );
+  };
+
+  const handleToggleRemember = (value: boolean) => {
+    if (value) {
+      showRememberWarning(() => setRememberCredentials(true));
+    } else {
+      setRememberCredentials(false);
+    }
+  };
+
+  const handleToggleBiometrics = (value: boolean) => {
+    if (value) {
+      showBiometricWarning(
+        () => setUseBiometrics(true),
+        biometricLabel ?? 'biometrics',
+      );
+    } else {
+      setUseBiometrics(false);
+    }
   };
 
   const errorMessage =
@@ -92,6 +155,42 @@ export default function LoginScreen() {
             style={styles.input}
           />
 
+          <View style={styles.toggleGroup}>
+            <Pressable
+              style={styles.toggleRow}
+              onPress={() => handleToggleRemember(!rememberCredentials)}
+            >
+              <Switch
+                value={rememberCredentials}
+                onValueChange={handleToggleRemember}
+                trackColor={{ false: colors.separator, true: colors.brand }}
+                thumbColor="#ffffff"
+                style={styles.switch}
+              />
+              <Text variant="body" style={{ flex: 1 }}>
+                Remember me
+              </Text>
+            </Pressable>
+
+            {biometricLabel && (
+              <Pressable
+                style={styles.toggleRow}
+                onPress={() => handleToggleBiometrics(!useBiometrics)}
+              >
+                <Switch
+                  value={useBiometrics}
+                  onValueChange={handleToggleBiometrics}
+                  trackColor={{ false: colors.separator, true: colors.brand }}
+                  thumbColor="#ffffff"
+                  style={styles.switch}
+                />
+                <Text variant="body" style={{ flex: 1 }}>
+                  Use {biometricLabel}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+
           {errorMessage && (
             <Text variant="error" style={styles.error}>
               {errorMessage}
@@ -141,6 +240,20 @@ const styles = StyleSheet.create({
   },
   input: {
     marginBottom: 12,
+  },
+  toggleGroup: {
+    alignSelf: 'stretch',
+    gap: 4,
+    marginBottom: 16,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 4,
+  },
+  switch: {
+    transform: [{ scaleX: 0.85 }, { scaleY: 0.85 }],
   },
   error: {
     marginBottom: 12,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import 'react-native-reanimated';
 
 import { AuthProvider, useAuth } from '@/contexts/auth-context';
+import { ReAuthModal } from '@/components/auth/ReAuthModal';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { Colors } from '@/constants/theme';
 import { queryClient } from '@/lib/query-client';
@@ -110,6 +111,7 @@ export default function RootLayout() {
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
             <RootLayoutNav />
+            <ReAuthModal />
           </AuthProvider>
         </QueryClientProvider>
       </SafeAreaProvider>

--- a/components/auth/ReAuthModal.tsx
+++ b/components/auth/ReAuthModal.tsx
@@ -1,0 +1,223 @@
+import { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+
+import { Text } from '@/components/ui/Text';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { useAuth } from '@/contexts/auth-context';
+import { useColorScheme } from '@/hooks/use-color-scheme';
+import { useBiometricAvailability, authenticateWithBiometrics } from '@/hooks/auth/use-biometric-availability';
+import { Colors, Fonts } from '@/constants/theme';
+import { login } from '@/lib/api/auth';
+import { ApiError } from '@/lib/api/client';
+import { SecureStorage } from '@/lib/storage';
+import { authKeys } from '@/lib/query-keys';
+import { useQueryClient } from '@tanstack/react-query';
+
+function getErrorMessage(error: unknown): string | null {
+  if (!error) return null;
+  if (error instanceof ApiError) {
+    if (error.status === 401) return 'Invalid password.';
+    if (error.status === 429) return 'Too many attempts. Please wait.';
+    if (error.isNetworkError) return 'Unable to reach server.';
+    return error.message;
+  }
+  if (error instanceof Error) return error.message;
+  return 'Something went wrong.';
+}
+
+export function ReAuthModal() {
+  const {
+    user,
+    serverUrl,
+    sessionExpired,
+    useBiometrics,
+    hasCredentials,
+    dismissSessionExpired,
+    setAuth,
+    clearAuth,
+  } = useAuth();
+  const queryClient = useQueryClient();
+  const colorScheme = useColorScheme();
+  const colors = Colors[colorScheme];
+  const biometricLabel = useBiometricAvailability();
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<unknown>(null);
+
+  const handleReAuth = async (pw?: string) => {
+    const pass = pw ?? password;
+    if (!pass || !user) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await login({ username: user.username, password: pass });
+      await setAuth(data.token, data.user, data.expiresAt);
+      await queryClient.invalidateQueries({queryKey: authKeys.me(serverUrl ?? '')});
+      dismissSessionExpired();
+      setPassword('');
+    } catch (e) {
+      setError(e);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleBiometric = async () => {
+    const success = await authenticateWithBiometrics();
+    if (!success) return;
+    const creds = await SecureStorage.getCredentials();
+    if (creds) {
+      await handleReAuth(creds.password);
+    }
+  };
+
+  const handleSignOut = async () => {
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    dismissSessionExpired();
+    await clearAuth();
+  };
+
+  const showBiometric = useBiometrics && hasCredentials && !!biometricLabel;
+
+  return (
+    <Modal
+      visible={sessionExpired}
+      transparent
+      animationType="fade"
+      statusBarTranslucent
+      onShow={() => {
+        if (showBiometric) handleBiometric();
+      }}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <Pressable style={styles.backdrop} onPress={() => {}} />
+        <View style={[styles.card, { backgroundColor: colors.card }]}>
+          <Ionicons
+            name="time-outline"
+            size={36}
+            color={colors.brand}
+            style={styles.icon}
+          />
+          <Text variant="title" style={styles.title}>
+            Session Expired
+          </Text>
+          <Text variant="subtitle" style={styles.subtitle}>
+            Enter your password to continue as{' '}
+            <Text
+              variant="subtitle"
+              style={{ fontFamily: Fonts.semiBold, color: colors.text }}
+            >
+              {user?.username}
+            </Text>
+          </Text>
+
+          <Input
+            placeholder="Password"
+            value={password}
+            onChangeText={(t) => {
+              setPassword(t);
+              setError(null);
+            }}
+            secureTextEntry
+            textContentType="password"
+            returnKeyType="go"
+            onSubmitEditing={() => handleReAuth()}
+            editable={!loading}
+            style={styles.input}
+          />
+
+          {error != null && (
+            <Text variant="error" style={styles.error}>
+              {getErrorMessage(error) ?? ''}
+            </Text>
+          )}
+
+          <Button
+            title="Continue"
+            onPress={() => handleReAuth()}
+            loading={loading}
+            style={styles.button}
+          />
+
+          {showBiometric && (
+            <Button
+              title={`Use ${biometricLabel}`}
+              variant="inline"
+              onPress={handleBiometric}
+              style={styles.biometric}
+            />
+          )}
+
+          <Button
+            title="Sign Out"
+            variant="inline"
+            onPress={handleSignOut}
+            style={styles.signOut}
+          />
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  backdrop: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+  },
+  card: {
+    width: '85%',
+    maxWidth: 360,
+    borderRadius: 20,
+    padding: 28,
+    alignItems: 'center',
+  },
+  icon: {
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 22,
+    marginBottom: 6,
+  },
+  subtitle: {
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  input: {
+    marginBottom: 12,
+  },
+  error: {
+    marginBottom: 12,
+  },
+  button: {
+    marginTop: 4,
+  },
+  biometric: {
+    marginTop: 12,
+  },
+  signOut: {
+    marginTop: 8,
+  },
+});

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import { setAuthToken, setBaseUrl, setOnSessionExpired, setOnAuthRefreshed } from '@/lib/api/client';
+import { login } from '@/lib/api/auth';
 import { AppStorage, SecureStorage } from '@/lib/storage';
 import type { HealthResponse, User } from '@/lib/types/auth';
 
@@ -54,7 +55,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     (async () => {
       try {
-        const [storedUrl, storedToken, storedUserJson, remember, bio, creds, storedExpiry] =
+        const [storedUrl, storedToken, storedUserJson, remember, bio, creds, storedExpiry, lastActive] =
           await Promise.all([
             AppStorage.getServerUrl(),
             SecureStorage.getToken(),
@@ -63,7 +64,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             SecureStorage.getUseBiometrics(),
             SecureStorage.getCredentials(),
             SecureStorage.getExpiresAt(),
+            SecureStorage.getLastActiveAt(),
           ]);
+
+        // Hard expire after 30 days of inactivity with full reset to login screen
+        const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+        if (lastActive && Date.now() - lastActive > THIRTY_DAYS_MS) {
+          await Promise.all([
+            AppStorage.deleteServerUrl(),
+            SecureStorage.deleteToken(),
+            SecureStorage.deleteUser(),
+            SecureStorage.deleteCredentials(),
+            SecureStorage.deleteRememberCredentials(),
+            SecureStorage.deleteUseBiometrics(),
+            SecureStorage.deleteExpiresAt(),
+            SecureStorage.deleteLastActiveAt(),
+          ]);
+          return;
+        }
 
         if (storedUrl) {
           setServerUrl(storedUrl);
@@ -124,7 +142,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const creds = await SecureStorage.getCredentials();
         if (creds) {
           try {
-            const { login } = await import('@/lib/api/auth');
             const data = await login(creds);
             setToken(data.token);
             setUser(data.user);
@@ -169,6 +186,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const saves: Promise<void>[] = [
       SecureStorage.setToken(newToken),
       SecureStorage.setUser(JSON.stringify(newUser)),
+      SecureStorage.setLastActiveAt(Date.now()),
     ];
     if (newExpiresAt) saves.push(SecureStorage.setExpiresAt(newExpiresAt));
     await Promise.all(saves);
@@ -200,6 +218,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       SecureStorage.deleteRememberCredentials(),
       SecureStorage.deleteUseBiometrics(),
       SecureStorage.deleteExpiresAt(),
+      SecureStorage.deleteLastActiveAt(),
     ]);
   }, []);
 

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,12 +1,13 @@
-import {
+import React, {
   createContext,
   useCallback,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
-import { setAuthToken, setBaseUrl } from '@/lib/api/client';
+import { setAuthToken, setBaseUrl, setOnSessionExpired, setOnAuthRefreshed } from '@/lib/api/client';
 import { AppStorage, SecureStorage } from '@/lib/storage';
 import type { HealthResponse, User } from '@/lib/types/auth';
 
@@ -18,10 +19,20 @@ type AuthContextValue = {
   user: User | null;
   isRestoring: boolean;
   serverHealth: ServerHealth | null;
+  rememberCredentials: boolean;
+  useBiometrics: boolean;
+  hasCredentials: boolean;
+  sessionExpired: boolean;
   setServer: (url: string, health: HealthResponse) => Promise<void>;
-  setAuth: (token: string, user: User) => Promise<void>;
+  setAuth: (token: string, user: User, expiresAt?: number) => Promise<void>;
   clearAuth: () => Promise<void>;
   clearAll: () => Promise<void>;
+  setRememberCredentials: (value: boolean) => Promise<void>;
+  setUseBiometrics: (value: boolean) => Promise<void>;
+  saveCredentials: (username: string, password: string) => Promise<void>;
+  updateExpiresAt: (expiresAt: number) => Promise<void>;
+  dismissSessionExpired: () => void;
+  setSessionExpired: (value: boolean) => void;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -32,16 +43,27 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [serverHealth, setServerHealth] = useState<ServerHealth | null>(null);
   const [isRestoring, setIsRestoring] = useState(true);
+  const [rememberCreds, setRememberCreds] = useState(false);
+  const [biometrics, setBiometrics] = useState(false);
+  const [hasCredentials, setHasCredentials] = useState(false);
+  const [sessionExpired, setSessionExpiredState] = useState(false);
+  const [expiresAt, setExpiresAt] = useState<number | null>(null);
+  const expiryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Restore persisted state on mount
   useEffect(() => {
     (async () => {
       try {
-        const [storedUrl, storedToken, storedUserJson] = await Promise.all([
-          AppStorage.getServerUrl(),
-          SecureStorage.getToken(),
-          SecureStorage.getUser(),
-        ]);
+        const [storedUrl, storedToken, storedUserJson, remember, bio, creds, storedExpiry] =
+          await Promise.all([
+            AppStorage.getServerUrl(),
+            SecureStorage.getToken(),
+            SecureStorage.getUser(),
+            SecureStorage.getRememberCredentials(),
+            SecureStorage.getUseBiometrics(),
+            SecureStorage.getCredentials(),
+            SecureStorage.getExpiresAt(),
+          ]);
 
         if (storedUrl) {
           setServerUrl(storedUrl);
@@ -58,11 +80,73 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             setUser(JSON.parse(storedUserJson));
           } catch {}
         }
+
+        setRememberCreds(remember);
+        setBiometrics(bio);
+        setHasCredentials(!!creds);
+        if (storedExpiry) setExpiresAt(storedExpiry);
       } finally {
         setIsRestoring(false);
       }
     })();
   }, []);
+
+  // Wire up interceptor callbacks
+  useEffect(() => {
+    setOnSessionExpired(() => setSessionExpiredState(true));
+    setOnAuthRefreshed((newToken, userJson, newExpiresAt) => {
+      setToken(newToken);
+      setAuthToken(newToken);
+      setExpiresAt(newExpiresAt);
+      try {
+        setUser(JSON.parse(userJson));
+      } catch {}
+    });
+    return () => {
+      setOnSessionExpired(null);
+      setOnAuthRefreshed(null);
+    };
+  }, []);
+
+  // Proactive session renewal — fires ~60s before token expires
+  useEffect(() => {
+    if (expiryTimer.current) clearTimeout(expiryTimer.current);
+    if (!expiresAt || !token) return;
+
+    const msUntilExpiry = expiresAt - Date.now();
+    // Fire 60s before expiry, or immediately if already past
+    const delay = Math.max(0, msUntilExpiry - 60_000);
+
+    expiryTimer.current = setTimeout(async () => {
+      // Try silent re-auth if remember is on
+      const remember = await SecureStorage.getRememberCredentials();
+      if (remember) {
+        const creds = await SecureStorage.getCredentials();
+        if (creds) {
+          try {
+            const { login } = await import('@/lib/api/auth');
+            const data = await login(creds);
+            setToken(data.token);
+            setUser(data.user);
+            setAuthToken(data.token);
+            setExpiresAt(data.expiresAt);
+            await Promise.all([
+              SecureStorage.setToken(data.token),
+              SecureStorage.setUser(JSON.stringify(data.user)),
+              SecureStorage.setExpiresAt(data.expiresAt),
+            ]);
+            return;
+          } catch {}
+        }
+      }
+      // Silent re-auth unavailable or failed
+      setSessionExpiredState(true);
+    }, delay);
+
+    return () => {
+      if (expiryTimer.current) clearTimeout(expiryTimer.current);
+    };
+  }, [expiresAt, token]);
 
   const setServer = useCallback(
     async (url: string, health: HealthResponse) => {
@@ -77,21 +161,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [],
   );
 
-  const setAuth = useCallback(async (newToken: string, newUser: User) => {
+  const setAuth = useCallback(async (newToken: string, newUser: User, newExpiresAt?: number) => {
     setToken(newToken);
     setUser(newUser);
     setAuthToken(newToken);
-    await Promise.all([
+    if (newExpiresAt) setExpiresAt(newExpiresAt);
+    const saves: Promise<void>[] = [
       SecureStorage.setToken(newToken),
       SecureStorage.setUser(JSON.stringify(newUser)),
-    ]);
+    ];
+    if (newExpiresAt) saves.push(SecureStorage.setExpiresAt(newExpiresAt));
+    await Promise.all(saves);
   }, []);
 
   const clearAuth = useCallback(async () => {
     setToken(null);
     setUser(null);
+    setExpiresAt(null);
     setAuthToken(null);
-    await Promise.all([SecureStorage.deleteToken(), SecureStorage.deleteUser()]);
+    await Promise.all([SecureStorage.deleteToken(), SecureStorage.deleteUser(), SecureStorage.deleteExpiresAt()]);
   }, []);
 
   const clearAll = useCallback(async () => {
@@ -101,11 +189,67 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setServerHealth(null);
     setBaseUrl('');
     setAuthToken(null);
+    setRememberCreds(false);
+    setBiometrics(false);
+    setHasCredentials(false);
     await Promise.all([
       AppStorage.deleteServerUrl(),
       SecureStorage.deleteToken(),
       SecureStorage.deleteUser(),
+      SecureStorage.deleteCredentials(),
+      SecureStorage.deleteRememberCredentials(),
+      SecureStorage.deleteUseBiometrics(),
+      SecureStorage.deleteExpiresAt(),
     ]);
+  }, []);
+
+  const setRememberCredentials = useCallback(
+    async (value: boolean) => {
+      setRememberCreds(value);
+      await SecureStorage.setRememberCredentials(value);
+      // If both remember and biometrics are off, clear stored credentials
+      if (!value && !biometrics) {
+        setHasCredentials(false);
+        await SecureStorage.deleteCredentials();
+      }
+    },
+    [biometrics],
+  );
+
+  const setUseBiometricsValue = useCallback(
+    async (value: boolean) => {
+      setBiometrics(value);
+      await SecureStorage.setUseBiometrics(value);
+      // If both remember and biometrics are off, clear stored credentials
+      if (!value && !rememberCreds) {
+        setHasCredentials(false);
+        await SecureStorage.deleteCredentials();
+      }
+    },
+    [rememberCreds],
+  );
+
+  const saveCredentials = useCallback(
+    async (username: string, password: string) => {
+      // Save if either remember or biometrics is enabled
+      if (!rememberCreds && !biometrics) return;
+      setHasCredentials(true);
+      await SecureStorage.setCredentials(username, password);
+    },
+    [rememberCreds, biometrics],
+  );
+
+  const updateExpiresAt = useCallback(async (newExpiresAt: number) => {
+    setExpiresAt(newExpiresAt);
+    await SecureStorage.setExpiresAt(newExpiresAt);
+  }, []);
+
+  const dismissSessionExpired = useCallback(() => {
+    setSessionExpiredState(false);
+  }, []);
+
+  const setSessionExpired = useCallback((value: boolean) => {
+    setSessionExpiredState(value);
   }, []);
 
   const value = useMemo<AuthContextValue>(
@@ -115,10 +259,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       user,
       isRestoring,
       serverHealth,
+      rememberCredentials: rememberCreds,
+      useBiometrics: biometrics,
+      hasCredentials,
+      sessionExpired,
       setServer,
       setAuth,
       clearAuth,
       clearAll,
+      setRememberCredentials,
+      setUseBiometrics: setUseBiometricsValue,
+      saveCredentials,
+      updateExpiresAt,
+      dismissSessionExpired,
+      setSessionExpired,
     }),
     [
       serverUrl,
@@ -126,10 +280,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       user,
       isRestoring,
       serverHealth,
+      rememberCreds,
+      biometrics,
+      hasCredentials,
+      sessionExpired,
       setServer,
       setAuth,
       clearAuth,
       clearAll,
+      setRememberCredentials,
+      setUseBiometricsValue,
+      saveCredentials,
+      updateExpiresAt,
+      dismissSessionExpired,
+      setSessionExpired,
     ],
   );
 

--- a/hooks/auth/use-biometric-availability.ts
+++ b/hooks/auth/use-biometric-availability.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a human-readable label ("Face ID", "Touch ID", "Biometrics") if
+ * biometric hardware is available and enrolled, or null if not.
+ *
+ * The expo-local-authentication module is loaded lazily so the app doesn't
+ * crash when the native module isn't linked (e.g. Expo Go).
+ */
+export function useBiometricAvailability(): string | null {
+  const [label, setLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const LA = await import('expo-local-authentication');
+        const compatible = await LA.hasHardwareAsync();
+        if (!compatible) return;
+        const enrolled = await LA.isEnrolledAsync();
+        if (!enrolled) return;
+        const types = await LA.supportedAuthenticationTypesAsync();
+        if (types.includes(LA.AuthenticationType.FACIAL_RECOGNITION)) {
+          setLabel('Face ID');
+        } else if (types.includes(LA.AuthenticationType.FINGERPRINT)) {
+          setLabel('Touch ID');
+        } else {
+          setLabel('Biometrics');
+        }
+      } catch {
+        // Native module not available — biometrics disabled
+      }
+    })();
+  }, []);
+
+  return label;
+}
+
+/**
+ * Prompt the user for biometric authentication. Returns true on success.
+ * Returns false if biometrics unavailable or user cancels.
+ */
+export async function authenticateWithBiometrics(
+  promptMessage = 'Authenticate to continue',
+): Promise<boolean> {
+  try {
+    const LA = await import('expo-local-authentication');
+    const result = await LA.authenticateAsync({
+      promptMessage,
+      fallbackLabel: 'Use password',
+      disableDeviceFallback: false,
+    });
+    return result.success;
+  } catch {
+    return false;
+  }
+}

--- a/hooks/auth/use-login.ts
+++ b/hooks/auth/use-login.ts
@@ -10,8 +10,8 @@ export function useLogin() {
 
   return useMutation({
     mutationFn: (creds: LoginRequest) => login(creds),
-    onSuccess: (data) => {
-      setAuth(data.token, data.user);
+    onSuccess: async (data) => {
+      await setAuth(data.token, data.user, data.expiresAt);
       queryClient.setQueryData(authKeys.me(serverUrl!), {
         user: data.user,
         expiresAt: data.expiresAt,

--- a/hooks/auth/use-logout.ts
+++ b/hooks/auth/use-logout.ts
@@ -1,17 +1,21 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/auth-context';
 import { logout } from '@/lib/api/auth';
+import { SecureStorage } from '@/lib/storage';
 
 export function useLogout() {
-  const { clearAuth } = useAuth();
+  const { clearAuth, setRememberCredentials, setUseBiometrics } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async () => {
       logout().catch(() => {});
     },
-    onSettled: () => {
-      clearAuth();
+    onSettled: async () => {
+      await setRememberCredentials(false);
+      await setUseBiometrics(false);
+      await SecureStorage.deleteCredentials();
+      await clearAuth();
       queryClient.clear();
     },
   });

--- a/hooks/auth/use-session.ts
+++ b/hooks/auth/use-session.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/auth-context';
 import { ApiError } from '@/lib/api/client';
@@ -6,11 +5,17 @@ import { getMe } from '@/lib/api/auth';
 import { authKeys } from '@/lib/query-keys';
 
 export function useSession() {
-  const { serverUrl, token, clearAuth } = useAuth();
+  const { serverUrl, token, updateExpiresAt } = useAuth();
 
-  const query = useQuery({
+  return useQuery({
     queryKey: authKeys.me(serverUrl ?? ''),
-    queryFn: () => getMe(),
+    queryFn: async () => {
+      const data = await getMe();
+      if (data.expiresAt) {
+        await updateExpiresAt(data.expiresAt);
+      }
+      return data;
+    },
     enabled: !!serverUrl && !!token,
     retry: (failureCount, error) => {
       if (error instanceof ApiError && error.status === 401) return false;
@@ -18,13 +23,4 @@ export function useSession() {
     },
     staleTime: 5 * 60 * 1000,
   });
-
-  // Clear auth on 401 so the routing gate redirects to login
-  useEffect(() => {
-    if (query.error instanceof ApiError && query.error.status === 401) {
-      clearAuth();
-    }
-  }, [query.error, clearAuth]);
-
-  return query;
 }

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import { SecureStorage } from '@/lib/storage';
 
 export class ApiError extends Error {
   constructor(
@@ -21,6 +22,9 @@ const api = axios.create({
 });
 
 let authToken: string | null = null;
+let onSessionExpired: (() => void) | null = null;
+let onAuthRefreshed: ((token: string, userJson: string, expiresAt: number) => void) | null = null;
+let reAuthPromise: Promise<boolean> | null = null;
 
 export function setBaseUrl(url: string) {
   api.defaults.baseURL = url ? `${url}/api` : '';
@@ -28,6 +32,72 @@ export function setBaseUrl(url: string) {
 
 export function setAuthToken(token: string | null) {
   authToken = token;
+}
+
+export function setOnSessionExpired(cb: (() => void) | null) {
+  onSessionExpired = cb;
+}
+
+export function setOnAuthRefreshed(
+  cb: ((token: string, userJson: string, expiresAt: number) => void) | null,
+) {
+  onAuthRefreshed = cb;
+}
+
+async function attemptSilentReAuth(): Promise<boolean> {
+  try {
+    const creds = await SecureStorage.getCredentials();
+    if (!creds) return false;
+
+    // Call login directly with a fresh axios instance to avoid interceptor recursion
+    const { data } = await axios.post<{
+      token: string;
+      expiresAt: number;
+      user: { id: number; username: string; role: string };
+    }>(`${api.defaults.baseURL}/auth/login`, creds, {
+      timeout: 10_000,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    authToken = data.token;
+    const userJson = JSON.stringify(data.user);
+    await Promise.all([
+      SecureStorage.setToken(data.token),
+      SecureStorage.setUser(userJson),
+      SecureStorage.setExpiresAt(data.expiresAt),
+    ]);
+    onAuthRefreshed?.(data.token, userJson, data.expiresAt);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function handle401(
+  originalRequest: InternalAxiosRequestConfig & { _retried?: boolean },
+): Promise<ReturnType<typeof api> | void> {
+  originalRequest._retried = true;
+
+  // Deduplicate concurrent re-auth attempts
+  if (!reAuthPromise) {
+    const remember = await SecureStorage.getRememberCredentials();
+    if (remember) {
+      reAuthPromise = attemptSilentReAuth().finally(() => {
+        reAuthPromise = null;
+      });
+    }
+  }
+
+  if (reAuthPromise) {
+    const success = await reAuthPromise;
+    if (success) {
+      originalRequest.headers.Authorization = `Bearer ${authToken}`;
+      return api(originalRequest);
+    }
+  }
+
+  // Silent re-auth not available or failed — notify UI
+  onSessionExpired?.();
 }
 
 api.interceptors.request.use((config) => {
@@ -39,13 +109,42 @@ api.interceptors.request.use((config) => {
 
 api.interceptors.response.use(
   (response) => response,
-  (error: AxiosError<{ error?: string; message?: string }>) => {
-    if (error.response) {
-      const data = error.response.data;
-      const msg = data?.error || data?.message || error.message;
-      throw new ApiError(error.response.status, msg, data);
+  async (error: AxiosError<{ error?: string; message?: string }>) => {
+    const originalRequest = error.config as InternalAxiosRequestConfig & {
+      _retried?: boolean;
+    };
+
+    // iOS swallows 401 responses that include WWW-Authenticate: Basic headers.
+    // NSURLSession intercepts them as authentication challenges and the response
+    // never reaches JS — the request just times out. When we get a timeout on an
+    // authenticated request, treat it as a likely expired session.
+    // See: https://github.com/facebook/react-native/issues/34883
+    if (
+      !error.response &&
+      authToken &&
+      originalRequest &&
+      !originalRequest._retried &&
+      error.code === 'ECONNABORTED'
+    ) {
+      const result = await handle401(originalRequest);
+      if (result) return result;
+      throw new ApiError(401, 'Session expired');
     }
-    throw new ApiError(0, 'Unable to reach server. Check your connection.');
+
+    if (!error.response) {
+      throw new ApiError(0, 'Unable to reach server. Check your connection.');
+    }
+
+    const { status, data } = error.response;
+
+    // Handle real 401s (is there is ever iOS fix in place or on Android)
+    if (status === 401 && originalRequest && !originalRequest._retried) {
+      const result = await handle401(originalRequest);
+      if (result) return result;
+    }
+
+    const msg = data?.error || data?.message || error.message;
+    throw new ApiError(status, msg, data);
   },
 );
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -10,6 +10,7 @@ const KEYS = {
   REMEMBER_CREDENTIALS: 'remember_credentials',
   USE_BIOMETRICS: 'use_biometrics',
   EXPIRES_AT: 'token_expires_at',
+  LAST_ACTIVE_AT: 'last_active_at',
 } as const;
 
 export const SecureStorage = {
@@ -71,6 +72,27 @@ export const SecureStorage = {
   async deleteExpiresAt(): Promise<void> {
     try {
       await SecureStore.deleteItemAsync(KEYS.EXPIRES_AT);
+    } catch {}
+  },
+
+  async getLastActiveAt(): Promise<number | null> {
+    try {
+      const val = await SecureStore.getItemAsync(KEYS.LAST_ACTIVE_AT);
+      return val ? Number(val) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async setLastActiveAt(ms: number): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(KEYS.LAST_ACTIVE_AT, String(ms));
+    } catch {}
+  },
+
+  async deleteLastActiveAt(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(KEYS.LAST_ACTIVE_AT);
     } catch {}
   },
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -5,6 +5,11 @@ const KEYS = {
   SERVER_URL: 'server_url',
   AUTH_TOKEN: 'auth_token',
   USER: 'user_json',
+  SAVED_USERNAME: 'saved_username',
+  SAVED_PASSWORD: 'saved_password',
+  REMEMBER_CREDENTIALS: 'remember_credentials',
+  USE_BIOMETRICS: 'use_biometrics',
+  EXPIRES_AT: 'token_expires_at',
 } as const;
 
 export const SecureStorage = {
@@ -45,6 +50,98 @@ export const SecureStorage = {
   async deleteUser(): Promise<void> {
     try {
       await SecureStore.deleteItemAsync(KEYS.USER);
+    } catch {}
+  },
+
+  async getExpiresAt(): Promise<number | null> {
+    try {
+      const val = await SecureStore.getItemAsync(KEYS.EXPIRES_AT);
+      return val ? Number(val) : null;
+    } catch {
+      return null;
+    }
+  },
+
+  async setExpiresAt(ms: number): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(KEYS.EXPIRES_AT, String(ms));
+    } catch {}
+  },
+
+  async deleteExpiresAt(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(KEYS.EXPIRES_AT);
+    } catch {}
+  },
+
+  async getCredentials(): Promise<{ username: string; password: string } | null> {
+    try {
+      const [username, password] = await Promise.all([
+        SecureStore.getItemAsync(KEYS.SAVED_USERNAME),
+        SecureStore.getItemAsync(KEYS.SAVED_PASSWORD),
+      ]);
+      if (username && password) return { username, password };
+      return null;
+    } catch {
+      return null;
+    }
+  },
+
+  async setCredentials(username: string, password: string): Promise<void> {
+    try {
+      await Promise.all([
+        SecureStore.setItemAsync(KEYS.SAVED_USERNAME, username),
+        SecureStore.setItemAsync(KEYS.SAVED_PASSWORD, password),
+      ]);
+    } catch {}
+  },
+
+  async deleteCredentials(): Promise<void> {
+    try {
+      await Promise.all([
+        SecureStore.deleteItemAsync(KEYS.SAVED_USERNAME),
+        SecureStore.deleteItemAsync(KEYS.SAVED_PASSWORD),
+      ]);
+    } catch {}
+  },
+
+  async getRememberCredentials(): Promise<boolean> {
+    try {
+      return (await SecureStore.getItemAsync(KEYS.REMEMBER_CREDENTIALS)) === 'true';
+    } catch {
+      return false;
+    }
+  },
+
+  async setRememberCredentials(value: boolean): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(KEYS.REMEMBER_CREDENTIALS, String(value));
+    } catch {}
+  },
+
+  async deleteRememberCredentials(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(KEYS.REMEMBER_CREDENTIALS);
+    } catch {}
+  },
+
+  async getUseBiometrics(): Promise<boolean> {
+    try {
+      return (await SecureStore.getItemAsync(KEYS.USE_BIOMETRICS)) === 'true';
+    } catch {
+      return false;
+    }
+  },
+
+  async setUseBiometrics(value: boolean): Promise<void> {
+    try {
+      await SecureStore.setItemAsync(KEYS.USE_BIOMETRICS, String(value));
+    } catch {}
+  },
+
+  async deleteUseBiometrics(): Promise<void> {
+    try {
+      await SecureStore.deleteItemAsync(KEYS.USE_BIOMETRICS);
     } catch {}
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "expo-image": "~55.0.6",
         "expo-linear-gradient": "~55.0.9",
         "expo-linking": "~55.0.9",
+        "expo-local-authentication": "~55.0.11",
         "expo-router": "~55.0.8",
         "expo-secure-store": "~55.0.9",
         "expo-splash-screen": "~55.0.13",
@@ -7203,6 +7204,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-55.0.11.tgz",
+      "integrity": "sha512-GTvDbI0HlsHTvgFVNo4x7fN8a/DV3D2qczqpco31R6O/8qU/yHcn4dTsbsCCr5A/2rmbEO12Trwr+TihiXyIBg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-manifests": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "expo-image": "~55.0.6",
     "expo-linear-gradient": "~55.0.9",
     "expo-linking": "~55.0.9",
+    "expo-local-authentication": "~55.0.11",
     "expo-router": "~55.0.8",
     "expo-secure-store": "~55.0.9",
     "expo-splash-screen": "~55.0.13",


### PR DESCRIPTION
Before there was no auto logout when token expired, and users had to re-login every 24 hours (or whatever the server is set to). 

- Add option for users to store credentials in `SecureStore` with optional biometric login. 
- Add max 30 day rolling window before fully clearing storage (resets with every auth, so if user goes 30 days without logging in at all, data will be fully wiped from storage