### PR TITLE
fix(auth): restore Face ID on session re-auth and fix credential persistence

### DIFF
--- a/__tests__/contexts/auth-context-test.tsx
+++ b/__tests__/contexts/auth-context-test.tsx
@@ -1,34 +1,34 @@
-jest.mock('expo-secure-store', () => ({
+jest.mock("expo-secure-store", () => ({
   getItemAsync: jest.fn(),
   setItemAsync: jest.fn(),
   deleteItemAsync: jest.fn(),
 }));
 
-jest.mock('@react-native-async-storage/async-storage', () => ({
+jest.mock("@react-native-async-storage/async-storage", () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
   removeItem: jest.fn(),
 }));
 
-jest.mock('@/lib/api/client', () => ({
+jest.mock("@/lib/api/client", () => ({
   setAuthToken: jest.fn(),
   setBaseUrl: jest.fn(),
   setOnSessionExpired: jest.fn(),
   setOnAuthRefreshed: jest.fn(),
 }));
 
-jest.mock('@/lib/api/auth', () => ({
+jest.mock("@/lib/api/auth", () => ({
   login: jest.fn(),
 }));
 
-import React, { useCallback } from 'react';
-import { Text, Pressable } from 'react-native';
-import { render, waitFor, fireEvent, act } from '@testing-library/react-native';
-import * as SecureStore from 'expo-secure-store';
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { AuthProvider, useAuth } from '@/contexts/auth-context';
-import { setAuthToken, setBaseUrl } from '@/lib/api/client';
-import { login } from '@/lib/api/auth';
+import React, { useCallback } from "react";
+import { Text, Pressable } from "react-native";
+import { render, waitFor, fireEvent, act } from "@testing-library/react-native";
+import * as SecureStore from "expo-secure-store";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { AuthProvider, useAuth } from "@/contexts/auth-context";
+import { setAuthToken, setBaseUrl } from "@/lib/api/client";
+import { login } from "@/lib/api/auth";
 
 const mockSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
 const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
@@ -40,14 +40,14 @@ function TestConsumer() {
 
   const handleSetAuth = useCallback(async () => {
     await auth.setAuth(
-      'new-token',
-      { id: 1, username: 'alice', role: 'user', permissions: {} },
+      "new-token",
+      { id: 1, username: "alice", role: "user", permissions: {} },
       Date.now() + 86400000,
     );
   }, [auth]);
 
   const handleSaveCredentials = useCallback(async () => {
-    await auth.saveCredentials('alice', 'pass123');
+    await auth.saveCredentials("alice", "pass123");
   }, [auth]);
 
   const handleRememberOn = useCallback(async () => {
@@ -72,11 +72,13 @@ function TestConsumer() {
 
   return (
     <>
-      <Text testID="token">{auth.token ?? 'null'}</Text>
-      <Text testID="serverUrl">{auth.serverUrl ?? 'null'}</Text>
-      <Text testID="user">{auth.user?.username ?? 'null'}</Text>
+      <Text testID="token">{auth.token ?? "null"}</Text>
+      <Text testID="serverUrl">{auth.serverUrl ?? "null"}</Text>
+      <Text testID="user">{auth.user?.username ?? "null"}</Text>
       <Text testID="sessionExpired">{String(auth.sessionExpired)}</Text>
-      <Text testID="rememberCredentials">{String(auth.rememberCredentials)}</Text>
+      <Text testID="rememberCredentials">
+        {String(auth.rememberCredentials)}
+      </Text>
       <Text testID="useBiometrics">{String(auth.useBiometrics)}</Text>
       <Text testID="hasCredentials">{String(auth.hasCredentials)}</Text>
       <Pressable testID="setAuth" onPress={handleSetAuth} />
@@ -109,320 +111,379 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe('AuthProvider — restore on mount', () => {
-  it('restores token, user, and server URL', async () => {
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+describe("AuthProvider — restore on mount", () => {
+  it("restores token, user, and server URL", async () => {
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'my-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "auth_token") return "my-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('my-token');
-      expect(getByTestId('serverUrl').props.children).toBe('https://my-server.com');
-      expect(getByTestId('user').props.children).toBe('alice');
+      expect(getByTestId("token").props.children).toBe("my-token");
+      expect(getByTestId("serverUrl").props.children).toBe(
+        "https://my-server.com",
+      );
+      expect(getByTestId("user").props.children).toBe("alice");
     });
 
-    expect(setBaseUrl).toHaveBeenCalledWith('https://my-server.com');
-    expect(setAuthToken).toHaveBeenCalledWith('my-token');
+    expect(setBaseUrl).toHaveBeenCalledWith("https://my-server.com");
+    expect(setAuthToken).toHaveBeenCalledWith("my-token");
   });
 
-  it('starts with null state when nothing stored', async () => {
+  it("starts with null state when nothing stored", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
-      expect(getByTestId('serverUrl').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
+      expect(getByTestId("serverUrl").props.children).toBe("null");
     });
   });
 });
 
-describe('AuthProvider — 30-day inactivity hard expire', () => {
+describe("AuthProvider — 30-day inactivity hard expire", () => {
   const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1000;
 
-  it('clears all data when inactive for more than 30 days', async () => {
+  it("clears all data when inactive for more than 30 days", async () => {
     const oldTimestamp = String(Date.now() - THIRTY_ONE_DAYS_MS);
 
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'old-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
-      if (key === 'last_active_at') return oldTimestamp;
+      if (key === "auth_token") return "old-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "last_active_at") return oldTimestamp;
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
-      expect(getByTestId('serverUrl').props.children).toBe('null');
-      expect(getByTestId('user').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
+      expect(getByTestId("serverUrl").props.children).toBe("null");
+      expect(getByTestId("user").props.children).toBe("null");
     });
 
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('auth_token');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('user_json');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('remember_credentials');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('use_biometrics');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('last_active_at');
-    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('server_url');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith("auth_token");
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith("user_json");
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_username",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_password",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "remember_credentials",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "use_biometrics",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "token_expires_at",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "last_active_at",
+    );
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith("server_url");
   });
 
-  it('restores normally when active within 30 days', async () => {
+  it("restores normally when active within 30 days", async () => {
     const recentTimestamp = String(Date.now() - 5 * 24 * 60 * 60 * 1000);
 
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'valid-token';
-      if (key === 'user_json') return '{"id":1,"username":"bob","role":"admin"}';
-      if (key === 'last_active_at') return recentTimestamp;
+      if (key === "auth_token") return "valid-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"bob","role":"admin"}';
+      if (key === "last_active_at") return recentTimestamp;
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('valid-token');
-      expect(getByTestId('user').props.children).toBe('bob');
+      expect(getByTestId("token").props.children).toBe("valid-token");
+      expect(getByTestId("user").props.children).toBe("bob");
     });
 
     expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalled();
   });
 
-  it('restores normally when lastActiveAt is not set (fresh install)', async () => {
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+  it("restores normally when lastActiveAt is not set (fresh install)", async () => {
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'fresh-token';
-      if (key === 'user_json') return '{"id":1,"username":"carol","role":"user"}';
+      if (key === "auth_token") return "fresh-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"carol","role":"user"}';
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('fresh-token');
-      expect(getByTestId('user').props.children).toBe('carol');
+      expect(getByTestId("token").props.children).toBe("fresh-token");
+      expect(getByTestId("user").props.children).toBe("carol");
     });
   });
 });
 
-describe('AuthProvider — setAuth bumps lastActiveAt', () => {
-  it('writes lastActiveAt to storage on setAuth', async () => {
+describe("AuthProvider — setAuth bumps lastActiveAt", () => {
+  it("writes lastActiveAt to storage on setAuth", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('setAuth'));
+      fireEvent.press(getByTestId("setAuth"));
     });
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('new-token');
+      expect(getByTestId("token").props.children).toBe("new-token");
     });
 
     expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
-      'last_active_at',
+      "last_active_at",
       expect.stringMatching(/^\d+$/),
     );
   });
 });
 
-describe('AuthProvider — credential clearing logic', () => {
-  it('does not clear credentials when turning off remember if biometrics is on', async () => {
+describe("AuthProvider — credential clearing logic", () => {
+  it("turning on remember disables biometrics but keeps stored credentials intact", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
-    // Enable biometrics first, then remember
     await act(async () => {
-      fireEvent.press(getByTestId('biometricsOn'));
-    });
-    await act(async () => {
-      fireEvent.press(getByTestId('rememberOn'));
+      fireEvent.press(getByTestId("biometricsOn"));
     });
 
     jest.clearAllMocks();
 
-    // Turn off remember — credentials should NOT be deleted because biometrics is still on
     await act(async () => {
-      fireEvent.press(getByTestId('rememberOff'));
+      fireEvent.press(getByTestId("rememberOn"));
     });
 
-    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_username');
-    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_password');
+    expect(getByTestId("rememberCredentials").props.children).toBe("true");
+    expect(getByTestId("useBiometrics").props.children).toBe("false");
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "use_biometrics",
+      "false",
+    );
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith(
+      "saved_username",
+    );
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith(
+      "saved_password",
+    );
   });
 
-  it('does not clear credentials when turning off biometrics if remember is on', async () => {
+  it("does not clear credentials when turning off biometrics if remember is on", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('rememberOn'));
+      fireEvent.press(getByTestId("rememberOn"));
     });
     await act(async () => {
-      fireEvent.press(getByTestId('biometricsOn'));
+      fireEvent.press(getByTestId("biometricsOn"));
     });
 
     jest.clearAllMocks();
 
     // Turn off biometrics — credentials should NOT be deleted because remember is still on
     await act(async () => {
-      fireEvent.press(getByTestId('biometricsOff'));
+      fireEvent.press(getByTestId("biometricsOff"));
     });
 
-    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_username');
-    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith('saved_password');
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith(
+      "saved_username",
+    );
+    expect(mockSecureStore.deleteItemAsync).not.toHaveBeenCalledWith(
+      "saved_password",
+    );
   });
 
-  it('clears credentials when both remember and biometrics are off', async () => {
+  it("clears credentials when both remember and biometrics are off", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
     // Enable remember, then turn it off (biometrics already off)
     await act(async () => {
-      fireEvent.press(getByTestId('rememberOn'));
+      fireEvent.press(getByTestId("rememberOn"));
     });
 
     jest.clearAllMocks();
 
     await act(async () => {
-      fireEvent.press(getByTestId('rememberOff'));
+      fireEvent.press(getByTestId("rememberOff"));
     });
 
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_username",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_password",
+    );
   });
 });
 
-describe('AuthProvider — saveCredentials conditional', () => {
-  it('does not save when neither remember nor biometrics is enabled', async () => {
+describe("AuthProvider — saveCredentials conditional", () => {
+  it("does not save when neither remember nor biometrics is enabled", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('rememberCredentials').props.children).toBe('false');
-      expect(getByTestId('useBiometrics').props.children).toBe('false');
+      expect(getByTestId("rememberCredentials").props.children).toBe("false");
+      expect(getByTestId("useBiometrics").props.children).toBe("false");
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('saveCredentials'));
+      fireEvent.press(getByTestId("saveCredentials"));
     });
 
-    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith('saved_username', 'alice');
-    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith('saved_password', 'pass123');
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith(
+      "saved_username",
+      "alice",
+    );
+    expect(mockSecureStore.setItemAsync).not.toHaveBeenCalledWith(
+      "saved_password",
+      "pass123",
+    );
   });
 
-  it('saves when remember is enabled', async () => {
+  it("saves when remember is enabled", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('rememberOn'));
+      fireEvent.press(getByTestId("rememberOn"));
     });
 
     jest.clearAllMocks();
 
     await act(async () => {
-      fireEvent.press(getByTestId('saveCredentials'));
+      fireEvent.press(getByTestId("saveCredentials"));
     });
 
-    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_username', 'alice');
-    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_password', 'pass123');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "saved_username",
+      "alice",
+    );
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "saved_password",
+      "pass123",
+    );
   });
 
-  it('saves when biometrics is enabled (even without remember)', async () => {
+  it("saves when biometrics is enabled (even without remember)", async () => {
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
     });
 
     await act(async () => {
-      fireEvent.press(getByTestId('biometricsOn'));
+      fireEvent.press(getByTestId("biometricsOn"));
     });
 
     jest.clearAllMocks();
 
     await act(async () => {
-      fireEvent.press(getByTestId('saveCredentials'));
+      fireEvent.press(getByTestId("saveCredentials"));
     });
 
-    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_username', 'alice');
-    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith('saved_password', 'pass123');
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "saved_username",
+      "alice",
+    );
+    expect(mockSecureStore.setItemAsync).toHaveBeenCalledWith(
+      "saved_password",
+      "pass123",
+    );
   });
 });
 
-describe('AuthProvider — clearAll', () => {
-  it('clears all state and storage including lastActiveAt', async () => {
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+describe("AuthProvider — clearAll", () => {
+  it("clears all state and storage including lastActiveAt", async () => {
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'my-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "auth_token") return "my-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('my-token');
+      expect(getByTestId("token").props.children).toBe("my-token");
     });
 
     jest.clearAllMocks();
 
     await act(async () => {
-      fireEvent.press(getByTestId('clearAll'));
+      fireEvent.press(getByTestId("clearAll"));
     });
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('null');
-      expect(getByTestId('serverUrl').props.children).toBe('null');
-      expect(getByTestId('user').props.children).toBe('null');
+      expect(getByTestId("token").props.children).toBe("null");
+      expect(getByTestId("serverUrl").props.children).toBe("null");
+      expect(getByTestId("user").props.children).toBe("null");
     });
 
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('last_active_at');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('token_expires_at');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_username');
-    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith('saved_password');
-    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('server_url');
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "last_active_at",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "token_expires_at",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_username",
+    );
+    expect(mockSecureStore.deleteItemAsync).toHaveBeenCalledWith(
+      "saved_password",
+    );
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith("server_url");
   });
 });
 
-describe('AuthProvider — proactive expiry timer', () => {
-  it('triggers sessionExpired when token expires and no remember', async () => {
+describe("AuthProvider — proactive expiry timer", () => {
+  it("triggers sessionExpired when token expires and no remember", async () => {
     const expiresIn = 120_000; // 2 minutes from now
     const expiresAt = String(Date.now() + expiresIn);
 
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'my-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
-      if (key === 'token_expires_at') return expiresAt;
-      if (key === 'remember_credentials') return null;
+      if (key === "auth_token") return "my-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "token_expires_at") return expiresAt;
+      if (key === "remember_credentials") return null;
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('my-token');
-      expect(getByTestId('sessionExpired').props.children).toBe('false');
+      expect(getByTestId("token").props.children).toBe("my-token");
+      expect(getByTestId("sessionExpired").props.children).toBe("false");
     });
 
     // Timer fires 60s before expiry, so at expiresIn - 60000 = 60000ms
@@ -431,11 +492,11 @@ describe('AuthProvider — proactive expiry timer', () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId('sessionExpired').props.children).toBe('true');
+      expect(getByTestId("sessionExpired").props.children).toBe("true");
     });
   });
 
-  it('silently re-auths when token expires and remember is on', async () => {
+  it("silently re-auths when token expires and remember is on", async () => {
     // Use real timers for this test since the timer callback has async/await
     jest.useRealTimers();
 
@@ -444,34 +505,35 @@ describe('AuthProvider — proactive expiry timer', () => {
     const expiresAt = String(Date.now() + expiresIn);
     const newExpiresAt = Date.now() + expiresIn + 86400000;
 
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'my-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
-      if (key === 'token_expires_at') return expiresAt;
-      if (key === 'remember_credentials') return 'true';
-      if (key === 'saved_username') return 'alice';
-      if (key === 'saved_password') return 'pass123';
+      if (key === "auth_token") return "my-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "token_expires_at") return expiresAt;
+      if (key === "remember_credentials") return "true";
+      if (key === "saved_username") return "alice";
+      if (key === "saved_password") return "pass123";
       return null;
     });
 
     mockLogin.mockResolvedValue({
-      token: 'renewed-token',
+      token: "renewed-token",
       expiresAt: newExpiresAt,
-      user: { id: 1, username: 'alice', role: 'user' },
+      user: { id: 1, username: "alice", role: "user" },
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('my-token');
+      expect(getByTestId("token").props.children).toBe("my-token");
     });
 
     // Timer fires at ~1s (61s - 60s buffer). Wait for re-auth to complete.
     await waitFor(
       () => {
-        expect(getByTestId('sessionExpired').props.children).toBe('false');
-        expect(getByTestId('token').props.children).toBe('renewed-token');
+        expect(getByTestId("sessionExpired").props.children).toBe("false");
+        expect(getByTestId("token").props.children).toBe("renewed-token");
       },
       { timeout: 5000 },
     );
@@ -479,22 +541,23 @@ describe('AuthProvider — proactive expiry timer', () => {
     jest.useFakeTimers();
   });
 
-  it('fires immediately when token is already expired on restore', async () => {
+  it("fires immediately when token is already expired on restore", async () => {
     const expiredAt = String(Date.now() - 60_000); // expired 1 minute ago
 
-    mockAsyncStorage.getItem.mockResolvedValue('https://my-server.com');
+    mockAsyncStorage.getItem.mockResolvedValue("https://my-server.com");
     mockSecureStore.getItemAsync.mockImplementation(async (key) => {
-      if (key === 'auth_token') return 'expired-token';
-      if (key === 'user_json') return '{"id":1,"username":"alice","role":"user"}';
-      if (key === 'token_expires_at') return expiredAt;
-      if (key === 'remember_credentials') return null;
+      if (key === "auth_token") return "expired-token";
+      if (key === "user_json")
+        return '{"id":1,"username":"alice","role":"user"}';
+      if (key === "token_expires_at") return expiredAt;
+      if (key === "remember_credentials") return null;
       return null;
     });
 
     const { getByTestId } = renderWithProvider();
 
     await waitFor(() => {
-      expect(getByTestId('token').props.children).toBe('expired-token');
+      expect(getByTestId("token").props.children).toBe("expired-token");
     });
 
     await act(async () => {
@@ -502,7 +565,7 @@ describe('AuthProvider — proactive expiry timer', () => {
     });
 
     await waitFor(() => {
-      expect(getByTestId('sessionExpired').props.children).toBe('true');
+      expect(getByTestId("sessionExpired").props.children).toBe("true");
     });
   });
 });

--- a/__tests__/lib/api/client-test.ts
+++ b/__tests__/lib/api/client-test.ts
@@ -23,6 +23,7 @@ import {
   setBaseUrl,
   setOnSessionExpired,
   setOnAuthRefreshed,
+  notifyReAuthResult,
 } from "@/lib/api/client";
 
 const mockFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -180,7 +181,7 @@ describe("response parsing", () => {
 });
 
 describe("401 handling", () => {
-  it("calls onSessionExpired when no saved credentials are available", async () => {
+  it("opens the re-auth modal and throws 401 when the user dismisses it", async () => {
     mockSecureStore.getItemAsync.mockResolvedValue(null);
     mockFetch.mockResolvedValueOnce(
       mockResponse({
@@ -189,11 +190,33 @@ describe("401 handling", () => {
         body: { error: "no" },
       }),
     );
-    const onExpired = jest.fn();
+    const onExpired = jest.fn(() => notifyReAuthResult(false));
     setOnSessionExpired(onExpired);
 
     await expect(api.get("/me")).rejects.toThrow(ApiError);
     expect(onExpired).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the failed request after the modal signals re-auth success", async () => {
+    mockSecureStore.getItemAsync.mockResolvedValue(null);
+    mockFetch.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 401,
+        body: { error: "expired" },
+      }),
+    );
+    mockFetch.mockResolvedValueOnce(mockResponse({ body: { ok: true } }));
+
+    setOnSessionExpired(() => {
+      setAuthToken("fresh-token");
+      notifyReAuthResult(true);
+    });
+
+    const res = await api.get<{ ok: boolean }>("/me");
+    expect(res.data).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("performs silent re-auth and retries when remember is on", async () => {
@@ -246,7 +269,7 @@ describe("401 handling", () => {
     mockFetch.mockResolvedValue(
       mockResponse({ ok: false, status: 401, body: { error: "still no" } }),
     );
-    const onExpired = jest.fn();
+    const onExpired = jest.fn(() => notifyReAuthResult(false));
     setOnSessionExpired(onExpired);
 
     await expect(api.get("/me")).rejects.toThrow(ApiError);

--- a/app.json
+++ b/app.json
@@ -21,9 +21,7 @@
         "foregroundImage": "./assets/images/aurral-logo.png"
       },
       "package": "com.aurral.aurralpocket",
-      "blockedPermissions": [
-        "android.permission.RECORD_AUDIO"
-      ]
+      "blockedPermissions": ["android.permission.RECORD_AUDIO"]
     },
     "web": {
       "output": "static"
@@ -48,7 +46,13 @@
       "expo-web-browser",
       "./plugins/ios/withFmtFix",
       "expo-audio",
-      "expo-asset"
+      "expo-asset",
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "Allow Aurral to use Face ID to sign you back in when your session expires."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,5 +1,21 @@
+import { AurralLogo } from "@/components/AurralLogo";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Text } from "@/components/ui/Text";
+import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/platform";
+import { Colors } from "@/constants/theme";
+import { useAuth } from "@/contexts/auth-context";
 import {
-  Alert,
+  authenticateWithBiometrics,
+  useBiometricAvailability,
+} from "@/hooks/auth/use-biometric-availability";
+import { useLogin } from "@/hooks/auth/use-login";
+import { useColorScheme } from "@/hooks/use-color-scheme";
+import { ApiError } from "@/lib/api/client";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as Haptics from "expo-haptics";
+import { Controller, useForm } from "react-hook-form";
+import {
   KeyboardAvoidingView,
   Pressable,
   ScrollView,
@@ -7,21 +23,7 @@ import {
   Switch,
   View,
 } from "react-native";
-import * as Haptics from "expo-haptics";
-import { useForm, Controller } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { AurralLogo } from "@/components/AurralLogo";
-import { Text } from "@/components/ui/Text";
-import { Button } from "@/components/ui/Button";
-import { Input } from "@/components/ui/Input";
-import { useAuth } from "@/contexts/auth-context";
-import { useLogin } from "@/hooks/auth/use-login";
-import { useBiometricAvailability } from "@/hooks/auth/use-biometric-availability";
-import { useColorScheme } from "@/hooks/use-color-scheme";
-import { Colors } from "@/constants/theme";
-import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/platform";
-import { ApiError } from "@/lib/api/client";
 
 const loginSchema = z.object({
   username: z.string().trim().min(1, "Username is required"),
@@ -43,28 +45,6 @@ function getErrorMessage(error: Error | null): string | null {
   return error.message;
 }
 
-function showRememberWarning(onConfirm: () => void) {
-  Alert.alert(
-    "Store Credentials",
-    "Your password will be saved in encrypted storage on this device so you can be automatically signed back in when your session expires.",
-    [
-      { text: "Cancel", style: "cancel" },
-      { text: "Enable", onPress: onConfirm },
-    ],
-  );
-}
-
-function showBiometricWarning(onConfirm: () => void, label: string) {
-  Alert.alert(
-    "Store Credentials",
-    `Your password will be saved in encrypted storage on this device so you can use ${label} to sign back in when your session expires.`,
-    [
-      { text: "Cancel", style: "cancel" },
-      { text: "Enable", onPress: onConfirm },
-    ],
-  );
-}
-
 export default function LoginScreen() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme];
@@ -75,7 +55,6 @@ export default function LoginScreen() {
     useBiometrics,
     setRememberCredentials,
     setUseBiometrics,
-    saveCredentials,
   } = useAuth();
   const loginMutation = useLogin();
   const biometricLabel = useBiometricAvailability();
@@ -90,37 +69,26 @@ export default function LoginScreen() {
   });
 
   const onSubmit = (data: LoginForm) => {
-    const trimmedUsername = data.username.trim();
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    loginMutation.mutate(
-      { username: trimmedUsername, password: data.password },
-      {
-        onSuccess: () => {
-          if (rememberCredentials || useBiometrics) {
-            saveCredentials(trimmedUsername, data.password);
-          }
-        },
-      },
-    );
+    loginMutation.mutate({
+      username: data.username.trim(),
+      password: data.password,
+    });
   };
 
   const handleToggleRemember = (value: boolean) => {
-    if (value) {
-      showRememberWarning(() => setRememberCredentials(true));
-    } else {
-      setRememberCredentials(false);
-    }
+    setRememberCredentials(value);
   };
 
-  const handleToggleBiometrics = (value: boolean) => {
-    if (value) {
-      showBiometricWarning(
-        () => setUseBiometrics(true),
-        biometricLabel ?? "biometrics",
-      );
-    } else {
+  const handleToggleBiometrics = async (value: boolean) => {
+    if (!value) {
       setUseBiometrics(false);
+      return;
     }
+    const ok = await authenticateWithBiometrics(
+      `Authenticate to enable ${biometricLabel ?? "biometrics"}`,
+    );
+    if (ok) setUseBiometrics(true);
   };
 
   const errorMessage =
@@ -203,21 +171,33 @@ export default function LoginScreen() {
             </Pressable>
 
             {biometricLabel && (
-              <Pressable
-                style={styles.toggleRow}
-                onPress={() => handleToggleBiometrics(!useBiometrics)}
-              >
-                <Switch
-                  value={useBiometrics}
-                  onValueChange={handleToggleBiometrics}
-                  trackColor={{ false: colors.separator, true: colors.brand }}
-                  thumbColor="#ffffff"
-                  style={styles.switch}
-                />
-                <Text variant="body" style={{ flex: 1 }}>
-                  Use {biometricLabel}
-                </Text>
-              </Pressable>
+              <View>
+                <Pressable
+                  style={[
+                    styles.toggleRow,
+                    rememberCredentials && styles.disabledRow,
+                  ]}
+                  onPress={() => handleToggleBiometrics(!useBiometrics)}
+                  disabled={rememberCredentials}
+                >
+                  <Switch
+                    value={useBiometrics && !rememberCredentials}
+                    onValueChange={handleToggleBiometrics}
+                    disabled={rememberCredentials}
+                    trackColor={{ false: colors.separator, true: colors.brand }}
+                    thumbColor="#ffffff"
+                    style={styles.switch}
+                  />
+                  <Text variant="body" style={{ flex: 1 }}>
+                    Use {biometricLabel}
+                  </Text>
+                </Pressable>
+                {rememberCredentials && (
+                  <Text variant="caption" style={styles.biometricHint}>
+                    Turn off Remember me to use {biometricLabel}
+                  </Text>
+                )}
+              </View>
             )}
           </View>
 
@@ -284,6 +264,13 @@ const styles = StyleSheet.create({
   },
   switch: {
     transform: [{ scaleX: 0.85 }, { scaleY: 0.85 }],
+  },
+  disabledRow: {
+    opacity: 0.4,
+  },
+  biometricHint: {
+    marginTop: -2,
+    marginBottom: 4,
   },
   error: {
     marginBottom: 12,

--- a/components/auth/ReAuthModal.tsx
+++ b/components/auth/ReAuthModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   KeyboardAvoidingView,
   Modal,
@@ -24,7 +24,7 @@ import {
 import { Colors, Fonts } from "@/constants/theme";
 import { KEYBOARD_AVOIDING_BEHAVIOR } from "@/constants/platform";
 import { login } from "@/lib/api/auth";
-import { ApiError } from "@/lib/api/client";
+import { ApiError, notifyReAuthResult } from "@/lib/api/client";
 import { SecureStorage } from "@/lib/storage";
 import { authKeys } from "@/lib/query-keys";
 import { useQueryClient } from "@tanstack/react-query";
@@ -86,6 +86,7 @@ export function ReAuthModal() {
       await queryClient.invalidateQueries({
         queryKey: authKeys.me(serverUrl ?? ""),
       });
+      notifyReAuthResult(true);
       dismissSessionExpired();
       reset();
     } catch (e) {
@@ -108,11 +109,26 @@ export function ReAuthModal() {
 
   const handleSignOut = async () => {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    notifyReAuthResult(false);
     dismissSessionExpired();
     await clearAuth();
   };
 
   const showBiometric = useBiometrics && hasCredentials && !!biometricLabel;
+
+  const autoTriggeredRef = useRef(false);
+  useEffect(() => {
+    if (!sessionExpired) {
+      autoTriggeredRef.current = false;
+      return;
+    }
+    if (!showBiometric || autoTriggeredRef.current) return;
+    autoTriggeredRef.current = true;
+    handleBiometric();
+    // handleBiometric is stable within a render; we intentionally avoid adding
+    // it to deps to prevent re-firing on unrelated re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionExpired, showBiometric]);
 
   return (
     <Modal
@@ -120,9 +136,6 @@ export function ReAuthModal() {
       transparent
       animationType="fade"
       statusBarTranslucent
-      onShow={() => {
-        if (showBiometric) handleBiometric();
-      }}
     >
       <KeyboardAvoidingView
         style={styles.overlay}

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -6,13 +6,18 @@ import React, {
   useMemo,
   useRef,
   useState,
-} from 'react';
-import { setAuthToken, setBaseUrl, setOnSessionExpired, setOnAuthRefreshed } from '@/lib/api/client';
-import { login } from '@/lib/api/auth';
-import { AppStorage, SecureStorage } from '@/lib/storage';
-import type { HealthResponse, User } from '@/lib/types/auth';
+} from "react";
+import {
+  setAuthToken,
+  setBaseUrl,
+  setOnSessionExpired,
+  setOnAuthRefreshed,
+} from "@/lib/api/client";
+import { login } from "@/lib/api/auth";
+import { AppStorage, SecureStorage } from "@/lib/storage";
+import type { HealthResponse, User } from "@/lib/types/auth";
 
-type ServerHealth = Pick<HealthResponse, 'authRequired' | 'onboardingRequired'>;
+type ServerHealth = Pick<HealthResponse, "authRequired" | "onboardingRequired">;
 
 type AuthContextValue = {
   serverUrl: string | null;
@@ -55,17 +60,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     (async () => {
       try {
-        const [storedUrl, storedToken, storedUserJson, remember, bio, creds, storedExpiry, lastActive] =
-          await Promise.all([
-            AppStorage.getServerUrl(),
-            SecureStorage.getToken(),
-            SecureStorage.getUser(),
-            SecureStorage.getRememberCredentials(),
-            SecureStorage.getUseBiometrics(),
-            SecureStorage.getCredentials(),
-            SecureStorage.getExpiresAt(),
-            SecureStorage.getLastActiveAt(),
-          ]);
+        const [
+          storedUrl,
+          storedToken,
+          storedUserJson,
+          remember,
+          bio,
+          creds,
+          storedExpiry,
+          lastActive,
+        ] = await Promise.all([
+          AppStorage.getServerUrl(),
+          SecureStorage.getToken(),
+          SecureStorage.getUser(),
+          SecureStorage.getRememberCredentials(),
+          SecureStorage.getUseBiometrics(),
+          SecureStorage.getCredentials(),
+          SecureStorage.getExpiresAt(),
+          SecureStorage.getLastActiveAt(),
+        ]);
 
         // Hard expire after 30 days of inactivity with full reset to login screen
         const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -165,39 +178,43 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, [expiresAt, token]);
 
-  const setServer = useCallback(
-    async (url: string, health: HealthResponse) => {
-      setServerUrl(url);
-      setBaseUrl(url);
-      setServerHealth({
-        authRequired: health.authRequired,
-        onboardingRequired: health.onboardingRequired,
-      });
-      await AppStorage.setServerUrl(url);
+  const setServer = useCallback(async (url: string, health: HealthResponse) => {
+    setServerUrl(url);
+    setBaseUrl(url);
+    setServerHealth({
+      authRequired: health.authRequired,
+      onboardingRequired: health.onboardingRequired,
+    });
+    await AppStorage.setServerUrl(url);
+  }, []);
+
+  const setAuth = useCallback(
+    async (newToken: string, newUser: User, newExpiresAt?: number) => {
+      setToken(newToken);
+      setUser(newUser);
+      setAuthToken(newToken);
+      if (newExpiresAt) setExpiresAt(newExpiresAt);
+      const saves: Promise<void>[] = [
+        SecureStorage.setToken(newToken),
+        SecureStorage.setUser(JSON.stringify(newUser)),
+        SecureStorage.setLastActiveAt(Date.now()),
+      ];
+      if (newExpiresAt) saves.push(SecureStorage.setExpiresAt(newExpiresAt));
+      await Promise.all(saves);
     },
     [],
   );
-
-  const setAuth = useCallback(async (newToken: string, newUser: User, newExpiresAt?: number) => {
-    setToken(newToken);
-    setUser(newUser);
-    setAuthToken(newToken);
-    if (newExpiresAt) setExpiresAt(newExpiresAt);
-    const saves: Promise<void>[] = [
-      SecureStorage.setToken(newToken),
-      SecureStorage.setUser(JSON.stringify(newUser)),
-      SecureStorage.setLastActiveAt(Date.now()),
-    ];
-    if (newExpiresAt) saves.push(SecureStorage.setExpiresAt(newExpiresAt));
-    await Promise.all(saves);
-  }, []);
 
   const clearAuth = useCallback(async () => {
     setToken(null);
     setUser(null);
     setExpiresAt(null);
     setAuthToken(null);
-    await Promise.all([SecureStorage.deleteToken(), SecureStorage.deleteUser(), SecureStorage.deleteExpiresAt()]);
+    await Promise.all([
+      SecureStorage.deleteToken(),
+      SecureStorage.deleteUser(),
+      SecureStorage.deleteExpiresAt(),
+    ]);
   }, []);
 
   const clearAll = useCallback(async () => {
@@ -205,7 +222,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setToken(null);
     setUser(null);
     setServerHealth(null);
-    setBaseUrl('');
+    setBaseUrl("");
     setAuthToken(null);
     setRememberCreds(false);
     setBiometrics(false);
@@ -225,12 +242,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const setRememberCredentials = useCallback(
     async (value: boolean) => {
       setRememberCreds(value);
-      await SecureStorage.setRememberCredentials(value);
+      const writes: Promise<void>[] = [
+        SecureStorage.setRememberCredentials(value),
+      ];
+      // Remember-me supersedes biometrics: when the user opts into silent
+      // re-auth, turn off the Face ID gate so stored state stays consistent.
+      if (value && biometrics) {
+        setBiometrics(false);
+        writes.push(SecureStorage.setUseBiometrics(false));
+      }
       // If both remember and biometrics are off, clear stored credentials
       if (!value && !biometrics) {
         setHasCredentials(false);
-        await SecureStorage.deleteCredentials();
+        writes.push(SecureStorage.deleteCredentials());
       }
+      await Promise.all(writes);
     },
     [biometrics],
   );
@@ -322,7 +348,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 export function useAuth() {
   const context = useContext(AuthContext);
   if (!context) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 }

--- a/hooks/auth/use-biometric-availability.ts
+++ b/hooks/auth/use-biometric-availability.ts
@@ -1,8 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
+import { Platform } from "react-native";
 
 /**
- * Returns a human-readable label ("Face ID", "Touch ID", "Biometrics") if
- * biometric hardware is available and enrolled, or null if not.
+ * Returns a human-readable label for the strongest enrolled biometric
+ * ("Face ID" / "Touch ID" on iOS, "Face Unlock" / "Fingerprint" on Android,
+ * or "Biometrics" as a fallback), or null if hardware is absent or unenrolled.
  *
  * The expo-local-authentication module is loaded lazily so the app doesn't
  * crash when the native module isn't linked (e.g. Expo Go).
@@ -13,18 +15,26 @@ export function useBiometricAvailability(): string | null {
   useEffect(() => {
     (async () => {
       try {
-        const LA = await import('expo-local-authentication');
+        const LA = await import("expo-local-authentication");
         const compatible = await LA.hasHardwareAsync();
         if (!compatible) return;
         const enrolled = await LA.isEnrolledAsync();
         if (!enrolled) return;
         const types = await LA.supportedAuthenticationTypesAsync();
-        if (types.includes(LA.AuthenticationType.FACIAL_RECOGNITION)) {
-          setLabel('Face ID');
-        } else if (types.includes(LA.AuthenticationType.FINGERPRINT)) {
-          setLabel('Touch ID');
+        const hasFace = types.includes(
+          LA.AuthenticationType.FACIAL_RECOGNITION,
+        );
+        const hasFingerprint = types.includes(
+          LA.AuthenticationType.FINGERPRINT,
+        );
+        if (Platform.OS === "ios") {
+          if (hasFace) setLabel("Face ID");
+          else if (hasFingerprint) setLabel("Touch ID");
+          else setLabel("Biometrics");
         } else {
-          setLabel('Biometrics');
+          if (hasFingerprint) setLabel("Fingerprint");
+          else if (hasFace) setLabel("Face Unlock");
+          else setLabel("Biometrics");
         }
       } catch {
         // Native module not available — biometrics disabled
@@ -40,13 +50,13 @@ export function useBiometricAvailability(): string | null {
  * Returns false if biometrics unavailable or user cancels.
  */
 export async function authenticateWithBiometrics(
-  promptMessage = 'Authenticate to continue',
+  promptMessage = "Authenticate to continue",
 ): Promise<boolean> {
   try {
-    const LA = await import('expo-local-authentication');
+    const LA = await import("expo-local-authentication");
     const result = await LA.authenticateAsync({
       promptMessage,
-      fallbackLabel: 'Use password',
+      fallbackLabel: "Use password",
       disableDeviceFallback: false,
     });
     return result.success;

--- a/hooks/auth/use-login.ts
+++ b/hooks/auth/use-login.ts
@@ -1,17 +1,26 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useAuth } from '@/contexts/auth-context';
-import { login } from '@/lib/api/auth';
-import { authKeys } from '@/lib/query-keys';
-import type { LoginRequest } from '@/lib/types/auth';
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@/contexts/auth-context";
+import { login } from "@/lib/api/auth";
+import { authKeys } from "@/lib/query-keys";
+import type { LoginRequest } from "@/lib/types/auth";
 
 export function useLogin() {
-  const { serverUrl, setAuth } = useAuth();
+  const {
+    serverUrl,
+    setAuth,
+    rememberCredentials,
+    useBiometrics,
+    saveCredentials,
+  } = useAuth();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (creds: LoginRequest) => login(creds),
-    onSuccess: async (data) => {
+    onSuccess: async (data, creds) => {
       await setAuth(data.token, data.user, data.expiresAt);
+      if (rememberCredentials || useBiometrics) {
+        await saveCredentials(creds.username, creds.password);
+      }
       queryClient.setQueryData(authKeys.me(serverUrl!), {
         user: data.user,
         expiresAt: data.expiresAt,

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -33,6 +33,7 @@ let onAuthRefreshed:
   | ((token: string, userJson: string, expiresAt: number) => void)
   | null = null;
 let reAuthPromise: Promise<boolean> | null = null;
+let resolveModalReAuth: ((success: boolean) => void) | null = null;
 const defaultTimeoutMs = 60_000;
 
 export function setBaseUrl(url: string) {
@@ -51,6 +52,15 @@ export function setOnAuthRefreshed(
   cb: ((token: string, userJson: string, expiresAt: number) => void) | null,
 ) {
   onAuthRefreshed = cb;
+}
+
+/**
+ * Resolve the pending re-auth promise when the user finishes (or abandons)
+ * the session-expired modal. Requests paused on the 401 will retry on
+ * success = true, or reject with 401 on success = false.
+ */
+export function notifyReAuthResult(success: boolean) {
+  resolveModalReAuth?.(success);
 }
 
 function buildUrl(path: string, params?: Record<string, unknown>): string {
@@ -106,22 +116,26 @@ async function handle401<T>(
   config: RequestConfig,
 ): Promise<ApiResponse<T> | null> {
   if (!reAuthPromise) {
-    const remember = await SecureStorage.getRememberCredentials();
-    if (remember) {
-      reAuthPromise = attemptSilentReAuth().finally(() => {
-        reAuthPromise = null;
+    reAuthPromise = (async () => {
+      const remember = await SecureStorage.getRememberCredentials();
+      if (remember && (await attemptSilentReAuth())) return true;
+      // Silent path unavailable or failed — open the modal and wait for the
+      // user to finish re-auth (password or Face ID → setAuth → notify).
+      const modalPromise = new Promise<boolean>((resolve) => {
+        resolveModalReAuth = resolve;
       });
-    }
+      onSessionExpired?.();
+      return modalPromise;
+    })().finally(() => {
+      reAuthPromise = null;
+      resolveModalReAuth = null;
+    });
   }
 
-  if (reAuthPromise) {
-    const success = await reAuthPromise;
-    if (success) {
-      return request<T>(method, path, body, { ...config, _retried: true });
-    }
+  const success = await reAuthPromise;
+  if (success) {
+    return request<T>(method, path, body, { ...config, _retried: true });
   }
-
-  onSessionExpired?.();
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Register `expo-local-authentication` as a config plugin so `NSFaceIDUsageDescription` is generated into the iOS Info.plist (without it iOS silently falls back to passcode). Also adds `USE_BIOMETRIC` / `USE_FINGERPRINT` on Android.
- Move `saveCredentials` into `useLogin`'s mutation-level `onSuccess` so it always runs — the previous mutate-call-level callback was being skipped because `setAuth` unmounted the login screen first, leaving `hasCredentials=false` forever.
- Close the retry-through-modal gap: `handle401` now pauses the failing request on a `reAuthPromise` that the modal resolves on success or sign-out, then retries the original request with the new token. Previously only the silent path retried, so after re-authing via the modal the user's original action was stuck showing a stale error.
- Make Remember me and Face ID mutually exclusive (Remember me wins for zero friction; Face ID switch is disabled with a helper caption when Remember me is on; enabling Remember me flips an already-on Face ID off).
- Platform-aware biometric label: Face ID / Touch ID on iOS, Fingerprint / Face Unlock on Android.
- Drop the `Alert.alert` confirmations on the login toggles — enabling Face ID now prompts the biometric directly as the consent step.
- Switch the Face ID auto-trigger on the modal from `Modal.onShow` to a `useEffect` guarded by a one-shot ref, so it fires reliably even if `useBiometricAvailability` resolves after the modal first renders.

Fixes #31.

## Test plan

- [x] `npx expo prebuild --clean && npx expo run:ios` — first Face ID attempt shows the iOS Face ID consent prompt.
- [x] On the login screen with Face ID on and Remember me off, sign in; hit **Invalidate Session (debug)** in settings; navigate to another tab. The re-auth modal opens and the Face ID prompt auto-fires. Passing Face ID silently re-auths and the originally failed request retries.
- [x] With Face ID on, sign out from the Sign Out button in the re-auth modal — the original caller gets a 401 error, no retry.
- [x] Turn Remember me on while Face ID is already on — Face ID flips off, stored credentials remain. Label reads "Turn off Remember me to use Face ID" under the disabled row.
- [x] With Remember me on only, invalidate session → silent re-auth (no modal).
- [x] Android dev build: fingerprint / face unlock equivalents surface correct label, prompt fires on session expiry.