### PR TITLE
fix(flow): refetch status immediately when tab regains focus

### DIFF
--- a/__tests__/hooks/flow/use-flow-status-test.tsx
+++ b/__tests__/hooks/flow/use-flow-status-test.tsx
@@ -1,0 +1,82 @@
+jest.mock("@/lib/api/flow", () => ({
+  getFlowStatus: jest.fn(),
+}));
+
+jest.mock("@/contexts/auth-context", () => ({
+  useAuth: jest.fn(() => ({ serverUrl: "http://test", token: "token" })),
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("expo-router/react-navigation", () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useFocusEffect } from "expo-router";
+import { useAuth } from "@/contexts/auth-context";
+import { getFlowStatus } from "@/lib/api/flow";
+import { useFlowStatus } from "@/hooks/flow/use-flow-status";
+
+const mockGetFlowStatus = getFlowStatus as jest.Mock;
+const mockUseAuth = useAuth as jest.Mock;
+const mockUseFocusEffect = useFocusEffect as jest.Mock;
+
+function latestFocusEffect(): () => void {
+  return mockUseFocusEffect.mock.calls.at(-1)![0];
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  }
+  return { wrapper: Wrapper };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({ serverUrl: "http://test", token: "token" });
+  mockGetFlowStatus.mockResolvedValue({ flows: [], jobs: [] });
+});
+
+describe("useFlowStatus", () => {
+  it("fetches once on mount", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useFlowStatus(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetFlowStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches immediately when the screen regains focus", async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useFlowStatus(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    act(() => latestFocusEffect()()); // initial focus — skipped
+    expect(mockGetFlowStatus).toHaveBeenCalledTimes(1);
+
+    act(() => latestFocusEffect()()); // user returns to the tab
+    await waitFor(() => expect(mockGetFlowStatus).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not refetch on focus while unauthenticated", async () => {
+    mockUseAuth.mockReturnValue({ serverUrl: null, token: null });
+    const { wrapper } = makeWrapper();
+    renderHook(() => useFlowStatus(), { wrapper });
+
+    act(() => latestFocusEffect()()); // initial focus — skipped
+    act(() => latestFocusEffect()()); // refocus, but disabled
+
+    expect(mockGetFlowStatus).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/use-refresh-on-focus-test.ts
+++ b/__tests__/hooks/use-refresh-on-focus-test.ts
@@ -1,0 +1,52 @@
+jest.mock("expo-router", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+import { act, renderHook } from "@testing-library/react-native";
+import { useFocusEffect } from "expo-router";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
+
+const mockUseFocusEffect = useFocusEffect as jest.Mock;
+
+/** Returns the effect most recently registered with useFocusEffect. */
+function latestFocusEffect(): () => void {
+  return mockUseFocusEffect.mock.calls.at(-1)![0];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useRefreshOnFocus", () => {
+  it("skips the initial focus", () => {
+    const refetch = jest.fn();
+    renderHook(() => useRefreshOnFocus(refetch));
+
+    act(() => latestFocusEffect()());
+
+    expect(refetch).not.toHaveBeenCalled();
+  });
+
+  it("refetches on every subsequent focus", () => {
+    const refetch = jest.fn();
+    renderHook(() => useRefreshOnFocus(refetch));
+
+    act(() => latestFocusEffect()()); // initial focus — skipped
+    act(() => latestFocusEffect()()); // tab regains focus
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    act(() => latestFocusEffect()());
+    expect(refetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps skipping only the first focus across re-renders", () => {
+    const refetch = jest.fn();
+    const { rerender } = renderHook(() => useRefreshOnFocus(refetch));
+
+    act(() => latestFocusEffect()()); // initial focus — skipped
+    rerender({});
+    act(() => latestFocusEffect()()); // refocus after re-render
+
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
+import { AppState, Platform } from "react-native";
+import type { AppStateStatus } from "react-native";
 import { Stack } from "expo-router";
 import { Theme, ThemeProvider } from "expo-router/react-navigation";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { focusManager, QueryClientProvider } from "@tanstack/react-query";
 import { useFonts } from "expo-font";
 import { DMSans_400Regular } from "@expo-google-fonts/dm-sans/400Regular";
 import { DMSans_500Medium } from "@expo-google-fonts/dm-sans/500Medium";
@@ -27,6 +29,14 @@ import { Colors } from "@/constants/theme";
 import { queryClient } from "@/lib/query-client";
 
 SplashScreen.preventAutoHideAsync();
+
+// Let React Query see app background/foreground transitions so queries with
+// refetchOnWindowFocus refresh on resume and intervals pause in background.
+function onAppStateChange(status: AppStateStatus) {
+  if (Platform.OS !== "web") {
+    focusManager.setFocused(status === "active");
+  }
+}
 
 const AurralDarkTheme: Theme = {
   dark: true,
@@ -107,6 +117,11 @@ function RootLayoutNav() {
 }
 
 export default function RootLayout() {
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", onAppStateChange);
+    return () => subscription.remove();
+  }, []);
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <KeyboardProvider>

--- a/hooks/flow/use-flow-status.ts
+++ b/hooks/flow/use-flow-status.ts
@@ -1,11 +1,12 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import {
   queryOptions,
   useQuery,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useFocusEffect } from "expo-router";
+import { useIsFocused } from "expo-router/react-navigation";
 import { useAuth } from "@/contexts/auth-context";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import { getFlowStatus } from "@/lib/api/flow";
 import { flowKeys } from "@/lib/query-keys";
 
@@ -16,35 +17,32 @@ export function flowStatusQueryOptions() {
     queryKey: flowKeys.status(),
     queryFn: getFlowStatus,
     staleTime: 1000,
+    refetchOnWindowFocus: "always",
     throwOnError: (_error, query) => query.state.data === undefined,
   });
 }
 
-/**
- * Tracks screen focus so polling only runs while the route is in view.
- * Shared between the query and suspense variants.
- */
-function useFocusPolling() {
-  const [focused, setFocused] = useState(false);
-  useFocusEffect(
-    useCallback(() => {
-      setFocused(true);
-      return () => setFocused(false);
-    }, []),
-  );
-  return focused;
-}
-
 export function useFlowStatus() {
   const { serverUrl, token } = useAuth();
-  const focused = useFocusPolling();
+  const isFocused = useIsFocused();
+  const enabled = !!serverUrl && !!token;
 
-  return useQuery({
+  const query = useQuery({
     ...flowStatusQueryOptions(),
-    enabled: !!serverUrl && !!token,
-    refetchInterval: focused ? POLL_INTERVAL_MS : false,
+    enabled,
+    refetchInterval: isFocused ? POLL_INTERVAL_MS : false,
     refetchIntervalInBackground: false,
   });
+
+  const { refetch } = query;
+  useRefreshOnFocus(
+    useCallback(() => {
+      // refetch() bypasses `enabled`, so guard it ourselves
+      if (enabled) refetch();
+    }, [enabled, refetch]),
+  );
+
+  return query;
 }
 
 /**
@@ -53,11 +51,15 @@ export function useFlowStatus() {
  * (auth is guaranteed there).
  */
 export function useFlowStatusSuspense() {
-  const focused = useFocusPolling();
+  const isFocused = useIsFocused();
 
-  return useSuspenseQuery({
+  const query = useSuspenseQuery({
     ...flowStatusQueryOptions(),
-    refetchInterval: focused ? POLL_INTERVAL_MS : false,
+    refetchInterval: isFocused ? POLL_INTERVAL_MS : false,
     refetchIntervalInBackground: false,
   });
+
+  useRefreshOnFocus(query.refetch);
+
+  return query;
 }

--- a/hooks/requests/use-requests-download-statuses.ts
+++ b/hooks/requests/use-requests-download-statuses.ts
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useIsFocused } from "expo-router/react-navigation";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import { getDownloadStatuses } from "@/lib/api/library";
 import { requestsKeys } from "@/lib/query-keys";
 import type { DownloadStatusMap } from "@/lib/types/library";
@@ -28,11 +29,22 @@ export function useRequestsDownloadStatuses(requests: Request[] | undefined) {
   const idsKey = activeAlbumIds.join(",");
   const enabled = activeAlbumIds.length > 0;
 
-  return useQuery<DownloadStatusMap>({
+  const query = useQuery<DownloadStatusMap>({
     queryKey: requestsKeys.downloadStatuses(idsKey),
     queryFn: () => getDownloadStatuses(activeAlbumIds),
     enabled,
     refetchInterval: enabled && isFocused ? ACTIVE_POLL_MS : false,
     refetchIntervalInBackground: false,
+    refetchOnWindowFocus: "always",
   });
+
+  const { refetch } = query;
+  useRefreshOnFocus(
+    useCallback(() => {
+      // refetch() bypasses `enabled`, so guard it ourselves
+      if (enabled) refetch();
+    }, [enabled, refetch]),
+  );
+
+  return query;
 }

--- a/hooks/requests/use-requests.ts
+++ b/hooks/requests/use-requests.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import {
   queryOptions,
   useQuery,
@@ -5,6 +6,7 @@ import {
 } from "@tanstack/react-query";
 import { useIsFocused } from "expo-router/react-navigation";
 import { useAuth } from "@/contexts/auth-context";
+import { useRefreshOnFocus } from "@/hooks/use-refresh-on-focus";
 import { getRequests } from "@/lib/api/requests";
 import { requestsKeys } from "@/lib/query-keys";
 
@@ -14,6 +16,7 @@ export function requestsQueryOptions() {
   return queryOptions({
     queryKey: requestsKeys.list(),
     queryFn: getRequests,
+    refetchOnWindowFocus: "always",
     throwOnError: (_error, query) => query.state.data === undefined,
   });
 }
@@ -21,13 +24,24 @@ export function requestsQueryOptions() {
 export function useRequests() {
   const { serverUrl, token } = useAuth();
   const isFocused = useIsFocused();
+  const enabled = !!serverUrl && !!token;
 
-  return useQuery({
+  const query = useQuery({
     ...requestsQueryOptions(),
-    enabled: !!serverUrl && !!token,
+    enabled,
     refetchInterval: isFocused ? ACTIVE_POLL_MS : false,
     refetchIntervalInBackground: false,
   });
+
+  const { refetch } = query;
+  useRefreshOnFocus(
+    useCallback(() => {
+      // refetch() bypasses `enabled`, so guard it ourselves
+      if (enabled) refetch();
+    }, [enabled, refetch]),
+  );
+
+  return query;
 }
 
 /**
@@ -37,9 +51,13 @@ export function useRequests() {
 export function useRequestsSuspense() {
   const isFocused = useIsFocused();
 
-  return useSuspenseQuery({
+  const query = useSuspenseQuery({
     ...requestsQueryOptions(),
     refetchInterval: isFocused ? ACTIVE_POLL_MS : false,
     refetchIntervalInBackground: false,
   });
+
+  useRefreshOnFocus(query.refetch);
+
+  return query;
 }

--- a/hooks/use-refresh-on-focus.ts
+++ b/hooks/use-refresh-on-focus.ts
@@ -1,0 +1,23 @@
+import { useCallback, useRef } from "react";
+import { useFocusEffect } from "expo-router";
+
+/**
+ * Calls `refetch` whenever the screen regains focus. Native tabs keep screens
+ * mounted, so React Query never sees a remount when the user returns to a
+ * tab — without this, a focus-gated `refetchInterval` waits a full interval
+ * before the first refetch. Skips the initial focus; the query handles its
+ * own first fetch.
+ */
+export function useRefreshOnFocus(refetch: () => void) {
+  const isFirstFocus = useRef(true);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isFirstFocus.current) {
+        isFirstFocus.current = false;
+        return;
+      }
+      refetch();
+    }, [refetch]),
+  );
+}


### PR DESCRIPTION
## Summary

Fixes the stale-data bug when navigating to the Flow tab (#131), and the same bug class on the Requests tab.

**Root cause:** NativeTabs keeps screens mounted across tab switches, so React Query never sees a remount when you return to a tab. The Flow screen gated its 3s poll on a custom `useFocusPolling` hook — re-entering the tab only restarted the interval, so the first refetch landed a full poll interval after navigation (and the `useFocusEffect` + local-state focus tracking was less reliable than the navigator's focus state). The Requests hooks already used `useIsFocused` but had the same first-interval gap.

## Changes

- **New `hooks/use-refresh-on-focus.ts`** — canonical TanStack RN recipe: skips the initial focus (the query handles its own first fetch), calls `refetch()` on every subsequent tab focus
- **`use-flow-status`** — replaces `useFocusPolling` with `useIsFocused()` (matching the requests hooks) + `useRefreshOnFocus`; non-suspense variant guards the manual refetch on `enabled` since `refetch()` bypasses it
- **`use-requests` / `use-requests-download-statuses`** — same focus refresh applied
- **App resume staleness** — wires `focusManager.setFocused` to `AppState` in the root layout and sets `refetchOnWindowFocus: "always"` on the flow/requests queries, so reopening the app also refreshes immediately (global default stays `false`; other screens unaffected). Polling now also genuinely pauses while backgrounded.

Out of scope: the library download-statuses hook still polls unfocused (separate issue), and WebSocket adoption from the aurral server's `weekly-flow` channel.

## Testing

- Jest: 601 tests pass. New tests for `useRefreshOnFocus` and `useFlowStatus`; the flow test fails against the old implementation, confirming it reproduces #131
- `tsc --noEmit` clean; the 3 lint errors are pre-existing in untouched files
- Manual simulator pass pending (switch tabs mid-download against a live aurral server)

Fixes #131