### PR TITLE
fix(flow): align flow editing with the aurral API contract

### DIFF
--- a/__tests__/components/flow/FocusEditor-test.tsx
+++ b/__tests__/components/flow/FocusEditor-test.tsx
@@ -1,0 +1,88 @@
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: jest.fn(() => "dark"),
+}));
+
+jest.mock("expo-haptics", () => ({
+  selectionAsync: jest.fn(() => Promise.resolve()),
+}));
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { FocusEditor } from "@/components/flow/FocusEditor";
+
+describe("FocusEditor", () => {
+  it("renders entry names, not array indices (regression #139)", () => {
+    const { getByText, queryByText } = render(
+      <FocusEditor
+        label="Tags"
+        placeholder="Add a tag"
+        value={["ambient", "shoegaze", "post-rock"]}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getByText("ambient")).toBeTruthy();
+    expect(getByText("shoegaze")).toBeTruthy();
+    expect(getByText("post-rock")).toBeTruthy();
+    expect(queryByText("0")).toBeNull();
+    expect(queryByText("1")).toBeNull();
+    expect(queryByText("2")).toBeNull();
+  });
+
+  it("shows empty state when there are no entries", () => {
+    const { getByText } = render(
+      <FocusEditor
+        label="Tags"
+        placeholder="Add a tag"
+        value={[]}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getByText("No filters added.")).toBeTruthy();
+  });
+
+  it("appends a trimmed entry on submit", () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText } = render(
+      <FocusEditor
+        label="Tags"
+        placeholder="Add a tag"
+        value={["ambient"]}
+        onChange={onChange}
+      />,
+    );
+    const input = getByPlaceholderText("Add a tag");
+    fireEvent.changeText(input, "  shoegaze  ");
+    fireEvent(input, "submitEditing");
+    expect(onChange).toHaveBeenCalledWith(["ambient", "shoegaze"]);
+  });
+
+  it("does not add duplicate entries", () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText } = render(
+      <FocusEditor
+        label="Tags"
+        placeholder="Add a tag"
+        value={["ambient"]}
+        onChange={onChange}
+      />,
+    );
+    const input = getByPlaceholderText("Add a tag");
+    fireEvent.changeText(input, "ambient");
+    fireEvent(input, "submitEditing");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("removes an entry via its chip remove button", () => {
+    const onChange = jest.fn();
+    const { getByLabelText } = render(
+      <FocusEditor
+        label="Tags"
+        placeholder="Add a tag"
+        value={["ambient", "shoegaze"]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.press(getByLabelText("Remove ambient"));
+    expect(onChange).toHaveBeenCalledWith(["shoegaze"]);
+  });
+});

--- a/__tests__/components/flow/MixPills-test.tsx
+++ b/__tests__/components/flow/MixPills-test.tsx
@@ -1,0 +1,29 @@
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: jest.fn(() => "dark"),
+}));
+
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { MixPills } from "@/components/flow/MixPills";
+
+describe("MixPills", () => {
+  it("renders a pill per non-zero channel", () => {
+    const { getByText } = render(
+      <MixPills mix={{ discover: 30, mix: 20, trending: 10, focus: 40 }} />,
+    );
+    expect(getByText("Discover 30%")).toBeTruthy();
+    expect(getByText("Mix 20%")).toBeTruthy();
+    expect(getByText("Trend 10%")).toBeTruthy();
+    expect(getByText("Focus 40%")).toBeTruthy();
+  });
+
+  it("hides pills for 0% channels", () => {
+    const { queryByText, getByText } = render(
+      <MixPills mix={{ discover: 50, mix: 50, trending: 0, focus: 0 }} />,
+    );
+    expect(getByText("Discover 50%")).toBeTruthy();
+    expect(getByText("Mix 50%")).toBeTruthy();
+    expect(queryByText("Trend 0%")).toBeNull();
+    expect(queryByText("Focus 0%")).toBeNull();
+  });
+});

--- a/__tests__/components/flow/MixSlider-test.tsx
+++ b/__tests__/components/flow/MixSlider-test.tsx
@@ -1,0 +1,54 @@
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: jest.fn(() => "dark"),
+}));
+
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import { MixSlider } from "@/components/flow/MixSlider";
+import type { MixPercent } from "@/lib/types/flow";
+
+const sum = (mix: MixPercent) =>
+  mix.discover + mix.mix + mix.trending + mix.focus;
+
+describe("MixSlider", () => {
+  it("renders a slider for all four channels", () => {
+    const { getByTestId } = render(
+      <MixSlider
+        value={{ discover: 50, mix: 30, trending: 20, focus: 0 }}
+        onChange={jest.fn()}
+      />,
+    );
+    expect(getByTestId("mix-slider-discover")).toBeTruthy();
+    expect(getByTestId("mix-slider-mix")).toBeTruthy();
+    expect(getByTestId("mix-slider-trending")).toBeTruthy();
+    expect(getByTestId("mix-slider-focus")).toBeTruthy();
+  });
+
+  it("rebalances other channels to keep the total at 100 when focus changes", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <MixSlider
+        value={{ discover: 50, mix: 30, trending: 20, focus: 0 }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent(getByTestId("mix-slider-focus"), "valueChange", 40);
+    const next: MixPercent = onChange.mock.calls[0][0];
+    expect(next.focus).toBe(40);
+    expect(sum(next)).toBe(100);
+  });
+
+  it("keeps the total at 100 when an existing channel changes", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <MixSlider
+        value={{ discover: 30, mix: 20, trending: 10, focus: 40 }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent(getByTestId("mix-slider-discover"), "valueChange", 70);
+    const next: MixPercent = onChange.mock.calls[0][0];
+    expect(next.discover).toBe(70);
+    expect(sum(next)).toBe(100);
+  });
+});

--- a/__tests__/lib/flow-form-schema-test.ts
+++ b/__tests__/lib/flow-form-schema-test.ts
@@ -1,0 +1,66 @@
+import { flowFormSchema } from "@/lib/flow-form-schema";
+import { createDefaultFlowForm } from "@/lib/types/flow";
+
+const validForm = () => ({
+  ...createDefaultFlowForm(),
+  scheduleDays: [1],
+});
+
+describe("flowFormSchema", () => {
+  it("accepts the default form", () => {
+    expect(flowFormSchema.safeParse(validForm()).success).toBe(true);
+  });
+
+  it("accepts a focused mix with at least one tag", () => {
+    const result = flowFormSchema.safeParse({
+      ...validForm(),
+      mix: { discover: 30, mix: 20, trending: 10, focus: 40 },
+      tags: ["ambient"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects focus > 0 with no tags or related artists", () => {
+    const result = flowFormSchema.safeParse({
+      ...validForm(),
+      mix: { discover: 30, mix: 20, trending: 10, focus: 40 },
+      tags: [],
+      relatedArtists: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Focus needs at least one genre tag or related artist",
+      );
+      expect(result.error.issues[0].path).toEqual(["tags"]);
+    }
+  });
+
+  it("rejects a mix that does not total 100 across all four channels", () => {
+    const result = flowFormSchema.safeParse({
+      ...validForm(),
+      mix: { discover: 50, mix: 30, trending: 20, focus: 40 },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects empty scheduleDays", () => {
+    const result = flowFormSchema.safeParse({
+      ...validForm(),
+      scheduleDays: [],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Pick at least one day");
+    }
+  });
+
+  it("accepts tags and related artists with focus at 0 (stored but inactive)", () => {
+    const result = flowFormSchema.safeParse({
+      ...validForm(),
+      tags: ["ambient", "shoegaze"],
+      relatedArtists: ["Slowdive"],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/(app)/(tabs)/(flow)/flow-edit.tsx
+++ b/app/(app)/(tabs)/(flow)/flow-edit.tsx
@@ -9,9 +9,8 @@ import {
   View,
 } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
 import { Text } from "@/components/ui/Text";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
@@ -24,35 +23,8 @@ import { FocusEditor } from "@/components/flow/FocusEditor";
 import { useCreateFlow, useFlow, useUpdateFlow } from "@/hooks/flow";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Fonts } from "@/constants/theme";
-import {
-  DEFAULT_FLOW_FORM,
-  FLOW_SIZE_MAX,
-  FLOW_SIZE_MIN,
-  type FlowFormValues,
-} from "@/lib/types/flow";
-
-const focusStrength = z.enum(["light", "medium", "heavy"]);
-
-const flowFormSchema = z.object({
-  name: z.string().trim().min(1, "Name is required"),
-  size: z.number().int().min(FLOW_SIZE_MIN).max(FLOW_SIZE_MAX),
-  mix: z
-    .object({
-      discover: z.number().min(0).max(100),
-      mix: z.number().min(0).max(100),
-      trending: z.number().min(0).max(100),
-    })
-    .refine((m) => Math.round(m.discover + m.mix + m.trending) === 100, {
-      message: "Mix must total 100%",
-    }),
-  deepDive: z.boolean(),
-  tags: z.record(z.string(), focusStrength),
-  relatedArtists: z.record(z.string(), focusStrength),
-  scheduleDays: z.array(z.number().int().min(0).max(6)),
-  scheduleTime: z.string().regex(/^\d{2}:\d{2}$/, "Invalid time"),
-});
-
-type FlowFormSchema = z.infer<typeof flowFormSchema>;
+import { createDefaultFlowForm, type FlowFormValues } from "@/lib/types/flow";
+import { flowFormSchema, type FlowFormSchema } from "@/lib/flow-form-schema";
 
 export default function FlowEditScreen() {
   const colors = Colors[useColorScheme()];
@@ -71,7 +43,7 @@ export default function FlowEditScreen() {
     formState: { errors },
   } = useForm<FlowFormSchema>({
     resolver: zodResolver(flowFormSchema),
-    defaultValues: DEFAULT_FLOW_FORM,
+    defaultValues: createDefaultFlowForm(),
   });
 
   useEffect(() => {
@@ -79,14 +51,22 @@ export default function FlowEditScreen() {
     reset({
       name: existingFlow.name,
       size: existingFlow.size,
-      mix: { ...existingFlow.mix },
+      mix: { ...existingFlow.mix, focus: existingFlow.mix.focus ?? 0 },
       deepDive: existingFlow.deepDive,
-      tags: { ...(existingFlow.tags ?? {}) },
-      relatedArtists: { ...(existingFlow.relatedArtists ?? {}) },
+      tags: [...(existingFlow.tags ?? [])],
+      relatedArtists: [...(existingFlow.relatedArtists ?? [])],
       scheduleDays: [...(existingFlow.scheduleDays ?? [])],
       scheduleTime: existingFlow.scheduleTime || "00:00",
     });
   }, [editingId, existingFlow, reset]);
+
+  const [watchedTags, watchedArtists, watchedMix] = useWatch({
+    control,
+    name: ["tags", "relatedArtists", "mix"],
+  });
+  const hasFocusEntries =
+    (watchedTags?.length ?? 0) > 0 || (watchedArtists?.length ?? 0) > 0;
+  const focusInactive = hasFocusEntries && (watchedMix?.focus ?? 0) === 0;
 
   const isPending = createFlow.isPending || updateFlow.isPending;
 
@@ -233,12 +213,19 @@ export default function FlowEditScreen() {
               />
             )}
           />
+          {focusInactive ? (
+            <Text variant="caption" style={{ color: colors.subtle }}>
+              Set Focus above 0% in the mix for these to take effect.
+            </Text>
+          ) : null}
+          {errors.tags?.message ? (
+            <Text variant="caption" style={{ color: colors.error }}>
+              {errors.tags.message}
+            </Text>
+          ) : null}
         </Section>
 
-        <Section
-          title="Schedule"
-          subtitle="Pick refresh days. Leave empty for manual-only runs."
-        >
+        <Section title="Schedule" subtitle="Pick the days this flow refreshes.">
           <Controller
             control={control}
             name="scheduleDays"
@@ -246,6 +233,11 @@ export default function FlowEditScreen() {
               <ScheduleDayPicker value={value} onChange={onChange} />
             )}
           />
+          {errors.scheduleDays?.message ? (
+            <Text variant="caption" style={{ color: colors.error }}>
+              {errors.scheduleDays.message}
+            </Text>
+          ) : null}
           <Controller
             control={control}
             name="scheduleTime"

--- a/components/flow/FocusEditor.tsx
+++ b/components/flow/FocusEditor.tsx
@@ -3,22 +3,16 @@ import { Pressable, StyleSheet, TextInput, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
 import { Text } from "@/components/ui/Text";
+import { Chip } from "@/components/ui/Chip";
 import { inputBaseStyle, inputThemedStyle } from "@/components/ui/Input";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Fonts } from "@/constants/theme";
-import type { FocusStrength } from "@/lib/types/flow";
-
-const STRENGTHS: { value: FocusStrength; label: string }[] = [
-  { value: "light", label: "Light" },
-  { value: "medium", label: "Medium" },
-  { value: "heavy", label: "Heavy" },
-];
 
 type Props = {
   label: string;
   placeholder: string;
-  value: Record<string, FocusStrength>;
-  onChange: (next: Record<string, FocusStrength>) => void;
+  value: string[];
+  onChange: (next: string[]) => void;
 };
 
 export function FocusEditor({ label, placeholder, value, onChange }: Props) {
@@ -26,31 +20,21 @@ export function FocusEditor({ label, placeholder, value, onChange }: Props) {
   const colors = Colors[colorScheme];
   const [draft, setDraft] = useState("");
 
-  const entries = Object.entries(value);
-
   const submit = () => {
     const trimmed = draft.trim();
     if (!trimmed) return;
-    if (value[trimmed]) {
+    if (value.includes(trimmed)) {
       setDraft("");
       return;
     }
     Haptics.selectionAsync();
-    onChange({ ...value, [trimmed]: "medium" });
+    onChange([...value, trimmed]);
     setDraft("");
   };
 
-  const remove = (key: string) => {
+  const remove = (entry: string) => {
     Haptics.selectionAsync();
-    const next = { ...value };
-    delete next[key];
-    onChange(next);
-  };
-
-  const setStrength = (key: string, strength: FocusStrength) => {
-    if (value[key] === strength) return;
-    Haptics.selectionAsync();
-    onChange({ ...value, [key]: strength });
+    onChange(value.filter((item) => item !== entry));
   };
 
   return (
@@ -85,74 +69,18 @@ export function FocusEditor({ label, placeholder, value, onChange }: Props) {
           <Ionicons name="add" size={20} color={colors.buttonPrimaryText} />
         </Pressable>
       </View>
-      {entries.length === 0 ? (
+      {value.length === 0 ? (
         <Text variant="caption">No filters added.</Text>
       ) : (
         <View style={styles.entries}>
-          {entries.map(([key, strength]) => (
-            <View
-              key={key}
-              style={[
-                styles.entry,
-                {
-                  backgroundColor: colors.brandMuted,
-                  borderColor: colors.separator,
-                },
-              ]}
-            >
-              <View style={styles.entryHead}>
-                <Text
-                  variant="body"
-                  style={{ color: colors.text, fontFamily: Fonts.semiBold }}
-                  numberOfLines={1}
-                >
-                  {key}
-                </Text>
-                <Pressable
-                  onPress={() => remove(key)}
-                  style={({ pressed }) => [
-                    styles.removeButton,
-                    { opacity: pressed ? 0.6 : 1 },
-                  ]}
-                  accessibilityLabel={`Remove ${key}`}
-                >
-                  <Ionicons name="close" size={16} color={colors.subtle} />
-                </Pressable>
-              </View>
-              <View style={styles.strengthRow}>
-                {STRENGTHS.map((option) => {
-                  const active = option.value === strength;
-                  return (
-                    <Pressable
-                      key={option.value}
-                      onPress={() => setStrength(key, option.value)}
-                      style={({ pressed }) => [
-                        styles.strengthChip,
-                        {
-                          backgroundColor: active
-                            ? colors.brand
-                            : colors.surfaceElevated,
-                          borderColor: active ? colors.brand : colors.separator,
-                          opacity: pressed ? 0.7 : 1,
-                        },
-                      ]}
-                    >
-                      <Text
-                        variant="caption"
-                        style={{
-                          color: active
-                            ? colors.buttonPrimaryText
-                            : colors.text,
-                          fontFamily: Fonts.semiBold,
-                        }}
-                      >
-                        {option.label}
-                      </Text>
-                    </Pressable>
-                  );
-                })}
-              </View>
-            </View>
+          {value.map((entry) => (
+            <Chip
+              key={entry}
+              label={entry}
+              variant="brand"
+              size="md"
+              onRemove={() => remove(entry)}
+            />
           ))}
         </View>
       )}
@@ -179,33 +107,8 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   entries: {
+    flexDirection: "row",
+    flexWrap: "wrap",
     gap: 8,
-  },
-  entry: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 12,
-    padding: 12,
-    gap: 10,
-  },
-  entryHead: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
-  removeButton: {
-    width: 28,
-    height: 28,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  strengthRow: {
-    flexDirection: "row",
-    gap: 6,
-  },
-  strengthChip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    borderRadius: 999,
-    borderWidth: StyleSheet.hairlineWidth,
   },
 });

--- a/components/flow/MixBar.tsx
+++ b/components/flow/MixBar.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, View } from "react-native";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors } from "@/constants/theme";
+import { useSourceMixColors } from "./MixPills";
 import type { MixPercent } from "@/lib/types/flow";
 
 type Props = {
@@ -10,12 +11,14 @@ type Props = {
 
 export function MixBar({ mix, height = 6 }: Props) {
   const colors = Colors[useColorScheme()];
-  const total = Math.max(1, mix.discover + mix.mix + mix.trending);
+  const palette = useSourceMixColors();
+  const total = Math.max(1, mix.discover + mix.mix + mix.trending + mix.focus);
 
   const segments = [
     { key: "discover", value: mix.discover, color: colors.brand },
     { key: "mix", value: mix.mix, color: colors.brandStrong },
     { key: "trending", value: mix.trending, color: colors.subtle },
+    { key: "focus", value: mix.focus, color: palette.focus },
   ];
 
   return (

--- a/components/flow/MixPills.tsx
+++ b/components/flow/MixPills.tsx
@@ -8,12 +8,14 @@ const SOURCE_MIX_COLORS_LIGHT = {
   discover: "#5e7591",
   mix: "#8b6464",
   trending: "#6e8159",
+  focus: "#7d6991",
 } as const;
 
 const SOURCE_MIX_COLORS_DARK = {
   discover: "#8a9eb8",
   mix: "#b78787",
   trending: "#94a578",
+  focus: "#a78fbe",
 } as const;
 
 export function useSourceMixColors() {
@@ -38,11 +40,27 @@ type Props = {
 
 export function MixPills({ mix }: Props) {
   const palette = useSourceMixColors();
+  const pills = [
+    {
+      label: `Discover ${mix.discover}%`,
+      value: mix.discover,
+      color: palette.discover,
+    },
+    { label: `Mix ${mix.mix}%`, value: mix.mix, color: palette.mix },
+    {
+      label: `Trend ${mix.trending}%`,
+      value: mix.trending,
+      color: palette.trending,
+    },
+    { label: `Focus ${mix.focus}%`, value: mix.focus, color: palette.focus },
+  ];
   return (
     <View style={styles.row}>
-      <MixPill label={`Discover ${mix.discover}%`} color={palette.discover} />
-      <MixPill label={`Mix ${mix.mix}%`} color={palette.mix} />
-      <MixPill label={`Trend ${mix.trending}%`} color={palette.trending} />
+      {pills
+        .filter((pill) => pill.value > 0)
+        .map((pill) => (
+          <MixPill key={pill.label} label={pill.label} color={pill.color} />
+        ))}
     </View>
   );
 }

--- a/components/flow/MixPresetPicker.tsx
+++ b/components/flow/MixPresetPicker.tsx
@@ -12,7 +12,10 @@ type Props = {
 
 function isSamePreset(a: MixPercent, b: MixPercent): boolean {
   return (
-    a.discover === b.discover && a.mix === b.mix && a.trending === b.trending
+    a.discover === b.discover &&
+    a.mix === b.mix &&
+    a.trending === b.trending &&
+    a.focus === b.focus
   );
 }
 

--- a/components/flow/MixSlider.tsx
+++ b/components/flow/MixSlider.tsx
@@ -11,11 +11,12 @@ const MAX_VALUE = 100;
 
 type Channel = keyof MixPercent;
 
-const CHANNEL_ORDER: Channel[] = ["discover", "mix", "trending"];
+const CHANNEL_ORDER: Channel[] = ["discover", "mix", "trending", "focus"];
 const CHANNEL_LABELS: Record<Channel, string> = {
   discover: "Discover",
   mix: "Library Mix",
   trending: "Trending",
+  focus: "Focus",
 };
 
 type Props = {
@@ -49,7 +50,7 @@ function rebalance(
       assigned += result[c];
     });
   }
-  const sum = result.discover + result.mix + result.trending;
+  const sum = CHANNEL_ORDER.reduce((acc, c) => acc + result[c], 0);
   if (sum !== MAX_VALUE) {
     const diff = MAX_VALUE - sum;
     result[others[0]] = Math.max(0, result[others[0]] + diff);

--- a/lib/flow-form-schema.ts
+++ b/lib/flow-form-schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+import { FLOW_SIZE_MAX, FLOW_SIZE_MIN } from "@/lib/types/flow";
+
+export const flowFormSchema = z
+  .object({
+    name: z.string().trim().min(1, "Name is required"),
+    size: z.number().int().min(FLOW_SIZE_MIN).max(FLOW_SIZE_MAX),
+    mix: z
+      .object({
+        discover: z.number().min(0).max(100),
+        mix: z.number().min(0).max(100),
+        trending: z.number().min(0).max(100),
+        focus: z.number().min(0).max(100),
+      })
+      .refine(
+        (m) => Math.round(m.discover + m.mix + m.trending + m.focus) === 100,
+        { message: "Mix must total 100%" },
+      ),
+    deepDive: z.boolean(),
+    tags: z.array(z.string()),
+    relatedArtists: z.array(z.string()),
+    scheduleDays: z
+      .array(z.number().int().min(0).max(6))
+      .min(1, "Pick at least one day"),
+    scheduleTime: z.string().regex(/^\d{2}:\d{2}$/, "Invalid time"),
+  })
+  .superRefine((values, ctx) => {
+    if (
+      values.mix.focus > 0 &&
+      values.tags.length === 0 &&
+      values.relatedArtists.length === 0
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tags"],
+        message: "Focus needs at least one genre tag or related artist",
+      });
+    }
+  });
+
+export type FlowFormSchema = z.infer<typeof flowFormSchema>;

--- a/lib/types/flow.ts
+++ b/lib/types/flow.ts
@@ -2,9 +2,8 @@ export type MixPercent = {
   discover: number;
   mix: number;
   trending: number;
+  focus: number;
 };
-
-export type FocusStrength = "light" | "medium" | "heavy";
 
 export type Flow = {
   id: string;
@@ -14,8 +13,8 @@ export type Flow = {
   mix: MixPercent;
   deepDive: boolean;
   recipe?: string | null;
-  tags: Record<string, FocusStrength>;
-  relatedArtists: Record<string, FocusStrength>;
+  tags: string[];
+  relatedArtists: string[];
   scheduleDays: number[];
   scheduleTime: string;
   nextRunAt: number | null;
@@ -117,8 +116,8 @@ export type FlowFormValues = {
   size: number;
   mix: MixPercent;
   deepDive: boolean;
-  tags: Record<string, FocusStrength>;
-  relatedArtists: Record<string, FocusStrength>;
+  tags: string[];
+  relatedArtists: string[];
   scheduleDays: number[];
   scheduleTime: string;
 };
@@ -127,47 +126,47 @@ export const DEFAULT_MIX: MixPercent = {
   discover: 50,
   mix: 30,
   trending: 20,
+  focus: 0,
 };
 
 export const DEFAULT_FLOW_SIZE = 30;
 
-export const DEFAULT_FLOW_FORM: FlowFormValues = {
+export const createDefaultFlowForm = (): FlowFormValues => ({
   name: "Discover",
   size: DEFAULT_FLOW_SIZE,
   mix: DEFAULT_MIX,
   deepDive: false,
-  tags: {},
-  relatedArtists: {},
-  scheduleDays: [],
+  tags: [],
+  relatedArtists: [],
+  scheduleDays: [new Date().getDay()],
   scheduleTime: "00:00",
-};
-
-export const FOCUS_STRENGTHS: Record<FocusStrength, number> = {
-  light: 20,
-  medium: 35,
-  heavy: 50,
-};
+});
 
 export const MIX_PRESETS: { id: string; label: string; mix: MixPercent }[] = [
   {
     id: "balanced",
     label: "Balanced",
-    mix: { discover: 50, mix: 30, trending: 20 },
+    mix: { discover: 50, mix: 30, trending: 20, focus: 0 },
   },
   {
     id: "discover",
     label: "Discover",
-    mix: { discover: 70, mix: 20, trending: 10 },
+    mix: { discover: 70, mix: 20, trending: 10, focus: 0 },
   },
   {
     id: "library",
     label: "Library",
-    mix: { discover: 25, mix: 65, trending: 10 },
+    mix: { discover: 25, mix: 65, trending: 10, focus: 0 },
   },
   {
     id: "trending",
     label: "Trending",
-    mix: { discover: 35, mix: 20, trending: 45 },
+    mix: { discover: 35, mix: 20, trending: 45, focus: 0 },
+  },
+  {
+    id: "focused",
+    label: "Focused",
+    mix: { discover: 30, mix: 20, trending: 10, focus: 40 },
   },
 ];
 


### PR DESCRIPTION
## Summary

Fixes #139 — tags and related artists displayed as `0, 1, 2…` when editing a flow.

The root cause was a contract mismatch with the aurral API, and fixing it surfaced two deeper problems, so this PR aligns the whole flow-edit model with the backend:

- **Display bug:** the API returns `tags`/`relatedArtists` as plain string arrays, but the app typed them as `Record<name, strength>`. Spreading the server array into the form produced `{0: …, 1: …}`, and FocusEditor rendered the index keys.
- **Strengths were fiction:** the per-entry light/medium/heavy strengths were silently discarded by the backend (`Object.keys()` normalization); the web UI has no strength concept either.
- **Focus was a placebo:** the backend mix has four channels (`discover/mix/trending/focus`) and tags/related artists only influence generation through the `focus` portion. The app only sent three, so pocket-created flows had `focus: 0` and focus entries never affected generated tracks.

## Changes

- `tags`/`relatedArtists` are now `string[]`; removed `FocusStrength` and the unused `FOCUS_STRENGTHS`
- Added the `focus` channel: 4th slider in `MixSlider`, 4th segment in `MixBar`, 4th color in the mix palette, `focus: 0` on existing presets plus a new **Focused** preset (`30/20/10/40`)
- `MixPills` hides any 0% channel, so existing flows don't grow a noisy `Focus 0%` pill
- `FocusEditor` entries are compact removable chips (shared `Chip` component) instead of card rows with dead strength controls
- Validation mirrors the backend: mix must total 100 across four channels; `focus > 0` requires at least one tag or related artist; `scheduleDays` requires at least one day (the backend rejects empty — the old "leave empty for manual-only runs" copy was wrong); new flows default to today's weekday
- Hint when focus entries exist but the focus channel is 0%: *"Set Focus above 0% in the mix for these to take effect."*
- Form schema extracted to `lib/flow-form-schema.ts` so it's testable without importing the route

## Tests

- `FocusEditor`: renders names not indices (regression for #139), add/trim/dedupe/remove on `string[]`
- `MixSlider`: renders four channels, rebalances to keep the total at 100
- `MixPills`: hides 0% channels
- `flowFormSchema`: focus-requires-entries, 4-channel 100% total, non-empty scheduleDays