### PR TITLE
fix(flow): edit a one-time snapshot so the status poll cannot clobber drafts

### DIFF
--- a/__tests__/hooks/flow/use-edit-snapshot-test.tsx
+++ b/__tests__/hooks/flow/use-edit-snapshot-test.tsx
@@ -1,0 +1,135 @@
+jest.mock("@/lib/api/flow", () => ({
+  getFlowStatus: jest.fn(),
+}));
+
+jest.mock("@/contexts/auth-context", () => ({
+  useAuth: jest.fn(() => ({ serverUrl: "http://test", token: "token" })),
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: jest.fn(),
+}));
+
+jest.mock("expo-router/react-navigation", () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
+import React from "react";
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { getFlowStatus } from "@/lib/api/flow";
+import { useEditSnapshot } from "@/hooks/flow/use-edit-snapshot";
+import { flowKeys } from "@/lib/query-keys";
+import type { Flow, FlowStatusSnapshot } from "@/lib/types/flow";
+
+const mockGetFlowStatus = getFlowStatus as jest.Mock;
+
+const flow: Flow = {
+  id: "flow-1",
+  name: "Morning Mix",
+  enabled: true,
+  size: 30,
+  mix: { discover: 50, mix: 30, trending: 20, focus: 0 },
+  deepDive: false,
+  tags: [],
+  relatedArtists: [],
+  scheduleDays: [1, 3],
+  scheduleTime: "09:00",
+  nextRunAt: null,
+};
+
+const status = {
+  flows: [flow],
+  sharedPlaylists: [],
+  jobs: [],
+} as unknown as FlowStatusSnapshot;
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+  }
+  return { client, wrapper: Wrapper };
+}
+
+const selectFlow = (s: FlowStatusSnapshot) =>
+  s.flows.find((f) => f.id === "flow-1");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useEditSnapshot", () => {
+  it("resolves synchronously from a warm cache without fetching", () => {
+    const { client, wrapper } = makeWrapper();
+    client.setQueryData(flowKeys.status(), status);
+
+    const { result } = renderHook(() => useEditSnapshot(true, selectFlow), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.snapshot).toEqual(flow);
+    expect(mockGetFlowStatus).not.toHaveBeenCalled();
+  });
+
+  it("does not update the snapshot when fresh status data lands in the cache", () => {
+    const { client, wrapper } = makeWrapper();
+    client.setQueryData(flowKeys.status(), status);
+
+    const { result } = renderHook(() => useEditSnapshot(true, selectFlow), {
+      wrapper,
+    });
+
+    act(() => {
+      client.setQueryData(flowKeys.status(), {
+        ...status,
+        flows: [{ ...flow, name: "Renamed", scheduleTime: "21:00" }],
+      });
+    });
+
+    expect(result.current.snapshot).toEqual(flow);
+  });
+
+  it("fetches once when the cache is cold", async () => {
+    mockGetFlowStatus.mockResolvedValue(status);
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useEditSnapshot(true, selectFlow), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.snapshot).toEqual(flow);
+    expect(mockGetFlowStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("settles with no snapshot when the cold fetch fails", async () => {
+    mockGetFlowStatus.mockRejectedValue(new Error("network down"));
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useEditSnapshot(true, selectFlow), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.snapshot).toBeUndefined();
+  });
+
+  it("does nothing when disabled", () => {
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useEditSnapshot(false, selectFlow), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.snapshot).toBeUndefined();
+    expect(mockGetFlowStatus).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/screens/flow-edit-test.tsx
+++ b/__tests__/screens/flow-edit-test.tsx
@@ -1,0 +1,177 @@
+jest.mock("@/lib/api/flow", () => ({
+  getFlowStatus: jest.fn(),
+  createFlow: jest.fn(),
+  updateFlow: jest.fn(),
+  deleteFlow: jest.fn(),
+  setFlowEnabled: jest.fn(),
+  startFlow: jest.fn(),
+  convertFlowToStaticPlaylist: jest.fn(),
+  updateSharedPlaylist: jest.fn(),
+  deleteSharedPlaylist: jest.fn(),
+  deleteSharedPlaylistTrack: jest.fn(),
+  setRetryCyclePaused: jest.fn(),
+  getWorkerSettings: jest.fn(),
+  updateWorkerSettings: jest.fn(),
+  getFlowStreamSource: jest.fn(),
+  getFlowArtworkSource: jest.fn(),
+}));
+
+jest.mock("@/contexts/auth-context", () => ({
+  useAuth: jest.fn(() => ({ serverUrl: "http://test", token: "token" })),
+}));
+
+jest.mock("@/hooks/use-color-scheme", () => ({
+  useColorScheme: jest.fn(() => "dark"),
+}));
+
+jest.mock("expo-haptics", () => ({
+  selectionAsync: jest.fn(() => Promise.resolve()),
+  impactAsync: jest.fn(() => Promise.resolve()),
+  notificationAsync: jest.fn(() => Promise.resolve()),
+  ImpactFeedbackStyle: { Light: "light", Medium: "medium" },
+  NotificationFeedbackType: { Success: "success", Error: "error" },
+}));
+
+jest.mock("expo-audio", () => ({
+  setAudioModeAsync: jest.fn(() => Promise.resolve()),
+  useAudioPlayer: jest.fn(() => ({})),
+  useAudioPlayerStatus: jest.fn(() => ({})),
+}));
+
+jest.mock("expo-localization", () => ({
+  getCalendars: jest.fn(() => [{ uses24hourClock: true }]),
+}));
+
+const mockBack = jest.fn();
+jest.mock("expo-router", () => ({
+  Stack: { Screen: () => null },
+  useFocusEffect: jest.fn(),
+  useLocalSearchParams: jest.fn(),
+  useRouter: jest.fn(() => ({ back: mockBack, push: jest.fn() })),
+}));
+
+jest.mock("expo-router/react-navigation", () => ({
+  useIsFocused: jest.fn(() => true),
+}));
+
+// The native wheel is replaced with a prop-transparent View so tests can read
+// selectedValue and drive onValueChange directly.
+jest.mock("@react-native-picker/picker", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  const Picker = function MockPicker({ children, ...props }: any) {
+    return React.createElement(
+      View,
+      { ...props, testID: "hour-picker" },
+      children,
+    );
+  };
+  Picker.Item = function MockPickerItem() {
+    return null;
+  };
+  return { Picker };
+});
+
+import React from "react";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useLocalSearchParams } from "expo-router";
+import { updateFlow } from "@/lib/api/flow";
+import { flowKeys } from "@/lib/query-keys";
+import type { Flow, FlowStatusSnapshot } from "@/lib/types/flow";
+import FlowEditScreen from "@/app/(app)/(tabs)/(flow)/flow-edit";
+
+const mockUseLocalSearchParams = useLocalSearchParams as jest.Mock;
+const mockUpdateFlow = updateFlow as jest.Mock;
+
+const flow: Flow = {
+  id: "flow-1",
+  name: "Morning Mix",
+  enabled: true,
+  size: 30,
+  mix: { discover: 50, mix: 30, trending: 20, focus: 0 },
+  deepDive: false,
+  tags: [],
+  relatedArtists: [],
+  scheduleDays: [1, 3],
+  scheduleTime: "09:00",
+  nextRunAt: null,
+};
+
+const status = {
+  flows: [flow],
+  sharedPlaylists: [],
+  jobs: [],
+} as unknown as FlowStatusSnapshot;
+
+function renderScreen() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  client.setQueryData(flowKeys.status(), status);
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <FlowEditScreen />
+    </QueryClientProvider>,
+  );
+  return { client, ...utils };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseLocalSearchParams.mockReturnValue({ id: "flow-1" });
+});
+
+describe("FlowEditScreen (editing)", () => {
+  it("hydrates the form from the cached flow", () => {
+    const { getByTestId, getByDisplayValue } = renderScreen();
+
+    expect(getByTestId("hour-picker").props.selectedValue).toBe(9);
+    expect(getByDisplayValue("Morning Mix")).toBeTruthy();
+  });
+
+  it("keeps the draft when fresh status data lands in the cache (#138)", () => {
+    const { client, getByTestId, getByDisplayValue } = renderScreen();
+
+    act(() => {
+      getByTestId("hour-picker").props.onValueChange(14);
+    });
+    expect(getByTestId("hour-picker").props.selectedValue).toBe(14);
+
+    // Simulate a 3s status poll delivering server-side changes mid-edit.
+    act(() => {
+      client.setQueryData(flowKeys.status(), {
+        ...status,
+        flows: [{ ...flow, name: "Renamed Elsewhere", scheduleTime: "07:00" }],
+      });
+    });
+
+    expect(getByTestId("hour-picker").props.selectedValue).toBe(14);
+    expect(getByDisplayValue("Morning Mix")).toBeTruthy();
+  });
+
+  it("saves the edited schedule time", async () => {
+    mockUpdateFlow.mockResolvedValue({ ...flow, scheduleTime: "14:00" });
+    const { getByTestId, getByText } = renderScreen();
+
+    act(() => {
+      getByTestId("hour-picker").props.onValueChange(14);
+    });
+    fireEvent.press(getByText("Save Changes"));
+
+    await waitFor(() =>
+      expect(mockUpdateFlow).toHaveBeenCalledWith(
+        "flow-1",
+        expect.objectContaining({ scheduleTime: "14:00" }),
+      ),
+    );
+    await waitFor(() => expect(mockBack).toHaveBeenCalled());
+  });
+
+  it("shows a not-found state when the flow is missing from the cache", () => {
+    mockUseLocalSearchParams.mockReturnValue({ id: "missing-flow" });
+    const { getByText } = renderScreen();
+
+    expect(getByText("Flow not found.")).toBeTruthy();
+  });
+});

--- a/app/(app)/(tabs)/(flow)/flow-edit.tsx
+++ b/app/(app)/(tabs)/(flow)/flow-edit.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import {
+  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Platform,
@@ -20,18 +20,76 @@ import { SizeStepper } from "@/components/flow/SizeStepper";
 import { ScheduleDayPicker } from "@/components/flow/ScheduleDayPicker";
 import { ScheduleHourPicker } from "@/components/flow/ScheduleHourPicker";
 import { FocusEditor } from "@/components/flow/FocusEditor";
-import { useCreateFlow, useFlow, useUpdateFlow } from "@/hooks/flow";
+import { useCreateFlow, useEditSnapshot, useUpdateFlow } from "@/hooks/flow";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Fonts } from "@/constants/theme";
-import { createDefaultFlowForm, type FlowFormValues } from "@/lib/types/flow";
+import {
+  createDefaultFlowForm,
+  type Flow,
+  type FlowFormValues,
+} from "@/lib/types/flow";
 import { flowFormSchema, type FlowFormSchema } from "@/lib/flow-form-schema";
+
+function toFormValues(flow: Flow): FlowFormValues {
+  return {
+    name: flow.name,
+    size: flow.size,
+    mix: { ...flow.mix, focus: flow.mix.focus ?? 0 },
+    deepDive: flow.deepDive,
+    tags: [...(flow.tags ?? [])],
+    relatedArtists: [...(flow.relatedArtists ?? [])],
+    scheduleDays: [...(flow.scheduleDays ?? [])],
+    scheduleTime: flow.scheduleTime || "00:00",
+  };
+}
 
 export default function FlowEditScreen() {
   const colors = Colors[useColorScheme()];
-  const router = useRouter();
   const params = useLocalSearchParams<{ id?: string }>();
   const editingId = typeof params.id === "string" ? params.id : null;
-  const existingFlow = useFlow(editingId ?? undefined);
+
+  // The form edits a one-time snapshot of the flow. Subscribing to the live
+  // status poll here would re-render every tick, snapping the iOS hour wheel
+  // back mid-gesture and resetting in-progress drafts (#138).
+  const { snapshot: existingFlow, isLoading } = useEditSnapshot(
+    !!editingId,
+    (status) => status.flows.find((flow) => flow.id === editingId),
+  );
+
+  if (editingId && isLoading) {
+    return (
+      <View
+        style={[styles.placeholder, { backgroundColor: colors.background }]}
+      >
+        <Stack.Screen options={{ title: "Edit Flow" }} />
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (editingId && !existingFlow) {
+    return (
+      <View
+        style={[styles.placeholder, { backgroundColor: colors.background }]}
+      >
+        <Stack.Screen options={{ title: "Edit Flow" }} />
+        <Text variant="body">Flow not found.</Text>
+      </View>
+    );
+  }
+
+  return <FlowEditForm editingId={editingId} existingFlow={existingFlow} />;
+}
+
+function FlowEditForm({
+  editingId,
+  existingFlow,
+}: {
+  editingId: string | null;
+  existingFlow: Flow | undefined;
+}) {
+  const colors = Colors[useColorScheme()];
+  const router = useRouter();
 
   const createFlow = useCreateFlow();
   const updateFlow = useUpdateFlow();
@@ -39,26 +97,13 @@ export default function FlowEditScreen() {
   const {
     control,
     handleSubmit,
-    reset,
     formState: { errors },
   } = useForm<FlowFormSchema>({
     resolver: zodResolver(flowFormSchema),
-    defaultValues: createDefaultFlowForm(),
+    defaultValues: existingFlow
+      ? toFormValues(existingFlow)
+      : createDefaultFlowForm(),
   });
-
-  useEffect(() => {
-    if (!editingId || !existingFlow) return;
-    reset({
-      name: existingFlow.name,
-      size: existingFlow.size,
-      mix: { ...existingFlow.mix, focus: existingFlow.mix.focus ?? 0 },
-      deepDive: existingFlow.deepDive,
-      tags: [...(existingFlow.tags ?? [])],
-      relatedArtists: [...(existingFlow.relatedArtists ?? [])],
-      scheduleDays: [...(existingFlow.scheduleDays ?? [])],
-      scheduleTime: existingFlow.scheduleTime || "00:00",
-    });
-  }, [editingId, existingFlow, reset]);
 
   const [watchedTags, watchedArtists, watchedMix] = useWatch({
     control,
@@ -304,6 +349,11 @@ function Section({
 }
 
 const styles = StyleSheet.create({
+  placeholder: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   content: {
     padding: 16,
     gap: 16,

--- a/app/(app)/(tabs)/(flow)/playlist-edit.tsx
+++ b/app/(app)/(tabs)/(flow)/playlist-edit.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import {
+  ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
   Platform,
@@ -16,14 +17,14 @@ import { Ionicons } from "@expo/vector-icons";
 import { Text } from "@/components/ui/Text";
 import { Input } from "@/components/ui/Input";
 import { Button } from "@/components/ui/Button";
-import {
-  useJobsForPlaylist,
-  useSharedPlaylist,
-  useUpdateSharedPlaylist,
-} from "@/hooks/flow";
+import { useEditSnapshot, useUpdateSharedPlaylist } from "@/hooks/flow";
 import { useColorScheme } from "@/hooks/use-color-scheme";
 import { Colors, Fonts } from "@/constants/theme";
-import type { SharedPlaylistTrack } from "@/lib/types/flow";
+import type {
+  FlowJob,
+  SharedPlaylist,
+  SharedPlaylistTrack,
+} from "@/lib/types/flow";
 
 const trackSchema = z.object({
   artistName: z.string(),
@@ -38,26 +39,90 @@ const playlistEditSchema = z.object({
   tracks: z.array(trackSchema).min(1, "Add at least one track"),
 });
 
-type PlaylistEditForm = z.infer<typeof playlistEditSchema>;
+type PlaylistEditFormValues = z.infer<typeof playlistEditSchema>;
+
+function toFormValues(
+  playlist: SharedPlaylist,
+  jobs: FlowJob[],
+): PlaylistEditFormValues {
+  const sourceTracks: SharedPlaylistTrack[] =
+    playlist.tracks && playlist.tracks.length > 0
+      ? playlist.tracks
+      : jobs.map((job) => ({
+          artistName: job.artistName,
+          trackName: job.trackName,
+          albumName: job.albumName ?? null,
+          artistMbid: job.artistMbid ?? null,
+          reason: job.reason ?? null,
+        }));
+  return { name: playlist.name, tracks: sourceTracks };
+}
 
 export default function PlaylistEditScreen() {
   const colors = Colors[useColorScheme()];
-  const router = useRouter();
   const params = useLocalSearchParams<{ id?: string }>();
   const playlistId = typeof params.id === "string" ? params.id : null;
 
-  const playlist = useSharedPlaylist(playlistId ?? undefined);
-  const jobs = useJobsForPlaylist(playlistId ?? undefined);
+  // The form edits a one-time snapshot of the playlist. Subscribing to the
+  // live status poll here would reset in-progress draft edits whenever the
+  // playlist changes server-side (same failure mode as #138).
+  const { snapshot, isLoading } = useEditSnapshot(!!playlistId, (status) => {
+    const playlist = status.sharedPlaylists.find((p) => p.id === playlistId);
+    if (!playlist) return undefined;
+    const jobs = (status.jobs ?? []).filter(
+      (job) => job.playlistType === playlistId && job.status !== "failed",
+    );
+    return { playlist, jobs };
+  });
+
+  if (isLoading) {
+    return (
+      <View style={[styles.empty, { backgroundColor: colors.background }]}>
+        <Stack.Screen options={{ title: "Edit Playlist" }} />
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (!playlistId || !snapshot) {
+    return (
+      <View style={[styles.empty, { backgroundColor: colors.background }]}>
+        <Stack.Screen options={{ title: "Edit Playlist" }} />
+        <Text variant="body">Playlist not found.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <PlaylistEditForm
+      playlistId={playlistId}
+      playlist={snapshot.playlist}
+      jobs={snapshot.jobs}
+    />
+  );
+}
+
+function PlaylistEditForm({
+  playlistId,
+  playlist,
+  jobs,
+}: {
+  playlistId: string;
+  playlist: SharedPlaylist;
+  jobs: FlowJob[];
+}) {
+  const colors = Colors[useColorScheme()];
+  const router = useRouter();
+
   const update = useUpdateSharedPlaylist();
 
   const {
     control,
     handleSubmit,
-    reset,
     formState: { errors },
-  } = useForm<PlaylistEditForm>({
+  } = useForm<PlaylistEditFormValues>({
     resolver: zodResolver(playlistEditSchema),
-    defaultValues: { name: "", tracks: [] },
+    defaultValues: toFormValues(playlist, jobs),
   });
 
   const { fields, move, remove } = useFieldArray({
@@ -65,25 +130,9 @@ export default function PlaylistEditScreen() {
     name: "tracks",
   });
 
-  useEffect(() => {
-    if (!playlist) return;
-    const sourceTracks: SharedPlaylistTrack[] =
-      playlist.tracks && playlist.tracks.length > 0
-        ? playlist.tracks
-        : jobs.map((job) => ({
-            artistName: job.artistName,
-            trackName: job.trackName,
-            albumName: job.albumName ?? null,
-            artistMbid: job.artistMbid ?? null,
-            reason: job.reason ?? null,
-          }));
-    reset({ name: playlist.name, tracks: sourceTracks });
-  }, [playlist, jobs, reset]);
-
   const isPending = update.isPending;
 
-  const onSubmit = (values: PlaylistEditForm) => {
-    if (!playlistId) return;
+  const onSubmit = (values: PlaylistEditFormValues) => {
     update.mutate(
       { playlistId, payload: values },
       {
@@ -101,14 +150,6 @@ export default function PlaylistEditScreen() {
     ],
     [colors.card, colors.separator],
   );
-
-  if (!playlist) {
-    return (
-      <View style={[styles.empty, { backgroundColor: colors.background }]}>
-        <Text variant="body">Playlist not found.</Text>
-      </View>
-    );
-  }
 
   return (
     <KeyboardAvoidingView

--- a/hooks/flow/index.ts
+++ b/hooks/flow/index.ts
@@ -1,4 +1,5 @@
 export { useFlowStatus, useFlowStatusSuspense } from "./use-flow-status";
+export { useEditSnapshot } from "./use-edit-snapshot";
 export {
   useFlow,
   useFlows,

--- a/hooks/flow/use-edit-snapshot.ts
+++ b/hooks/flow/use-edit-snapshot.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { flowStatusQueryOptions } from "./use-flow-status";
+import type { FlowStatusSnapshot } from "@/lib/types/flow";
+
+type Result<T> = {
+  snapshot: T | undefined;
+  isLoading: boolean;
+};
+
+/**
+ * Resolves the entity being edited from the flow status cache exactly once,
+ * with a one-shot fetch fallback for cold starts (deep links).
+ *
+ * Edit screens must not subscribe to the polling status query: a poll-tick
+ * re-render mid-gesture snaps the iOS hour wheel back to the stale value
+ * (#138), and a background refetch must never reset an in-progress draft.
+ */
+export function useEditSnapshot<T>(
+  enabled: boolean,
+  select: (status: FlowStatusSnapshot) => T | undefined,
+): Result<T> {
+  const queryClient = useQueryClient();
+  const selectRef = useRef(select);
+  useEffect(() => {
+    selectRef.current = select;
+  });
+
+  const [state, setState] = useState<Result<T>>(() => {
+    if (!enabled) return { snapshot: undefined, isLoading: false };
+    const cached = queryClient.getQueryData<FlowStatusSnapshot>(
+      flowStatusQueryOptions().queryKey,
+    );
+    if (cached) return { snapshot: select(cached), isLoading: false };
+    return { snapshot: undefined, isLoading: true };
+  });
+
+  useEffect(() => {
+    if (!state.isLoading) return;
+    let cancelled = false;
+    queryClient
+      .ensureQueryData(flowStatusQueryOptions())
+      .then((status) => {
+        if (cancelled) return;
+        setState({ snapshot: selectRef.current(status), isLoading: false });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ snapshot: undefined, isLoading: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [queryClient, state.isLoading]);
+
+  return state;
+}


### PR DESCRIPTION
## What
Fixes #138 — the schedule time on the flow edit screen could not be changed because the 3-second status poll re-rendered the form mid-gesture, snapping the iOS hour wheel back to its old value.

## Why
`flow-edit` resolved its flow through `useFlow` → `useFlowStatus`, which polls every 3 seconds while focused. Each poll tick re-rendered the screen; a re-render that passes the stale `selectedValue` to the native wheel while the user is still dragging resets the wheel before `onValueChange` fires, so the time change never registers. The `reset()` effect on the same screen also wiped the entire in-progress draft whenever the flow object changed server-side mid-edit. `playlist-edit` shared the identical subscribe-and-reset pattern and had the same latent draft-loss bug.

## Changes
- Added `useEditSnapshot` (hooks/flow/use-edit-snapshot.ts): resolves the entity being edited from the flow status cache exactly once, with a one-shot `ensureQueryData` fallback for cold-start deep links — no subscription to the polling query
- `flow-edit.tsx`: split into a snapshot-gated screen (loading / not-found states) and a pure form component that hydrates via `useForm` `defaultValues`; the `reset()` effect and `useFlow` subscription are gone
- `playlist-edit.tsx`: same restructure — snapshot-gated screen plus a form component; tracks fall back to the playlist's job list captured in the same snapshot
- Save semantics unchanged: full form payload, last-write-wins
- Tests: hook-level coverage for warm-cache/cold-fetch/failure/disabled paths, plus a screen-level regression test asserting fresh status data landing in the cache does not move the hour picker or reset the draft