### PR TITLE
fix(ios): sanitize prerelease version for CFBundleShortVersionString

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,3 +1,4 @@
+/* global __dirname */
 // Extends the static app.json. Expo loads app.json and passes it here as
 // `config`, with .env / .env.local already merged into process.env.
 //
@@ -26,8 +27,19 @@ function resolveShazamToken() {
 }
 
 module.exports = ({ config }) => {
+  // release-please bumps app.json's version, and on the `test` track that's a
+  // prerelease string like "0.10.0-test". iOS CFBundleShortVersionString only
+  // accepts one-to-three dot-separated integers, so strip any prerelease/build
+  // suffix for the native marketing version. The full string is preserved in
+  // `extra.fullVersion` so the About screen can still show "-test" on QA builds.
+  const fullVersion = config.version;
+  if (typeof config.version === "string") {
+    config.version = config.version.split("-")[0];
+  }
+
   config.extra = {
     ...(config.extra ?? {}),
+    fullVersion,
     shazamDeveloperToken: resolveShazamToken(),
   };
   return config;

--- a/components/settings/sections/AboutSection.tsx
+++ b/components/settings/sections/AboutSection.tsx
@@ -5,7 +5,10 @@ import { useAuth } from "@/contexts/auth-context";
 
 export function AboutSection() {
   const { serverUrl } = useAuth();
-  const version = Constants.expoConfig?.version ?? "unknown";
+  const version =
+    (Constants.expoConfig?.extra?.fullVersion as string | undefined) ??
+    Constants.expoConfig?.version ??
+    "unknown";
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
## Problem
The TestFlight upload from the `test` track fails:

> CFBundleShortVersionString, "0.10.0-test", must be composed of one to three period-separated integers. (-19239)

release-please on the test track bumps `app.json`'s `expo.version` to a prerelease string (`0.10.0-test`), which flows straight into iOS `CFBundleShortVersionString`. Apple only accepts 1–3 dot-separated integers there.

## Fix
In `app.config.js`, strip the prerelease/build suffix from the native marketing version (`0.10.0-test` → `0.10.0`), and stash the full string in `extra.fullVersion`. The About screen now reads `fullVersion`, so QA builds still show `0.10.0-test`. The build number (`CFBundleVersion`) keeps incrementing via EAS remote `autoIncrement`, so TestFlight builds stay distinct under the shared `0.10.0` marketing version.

No-op on `main` (stable versions have no suffix). Resilient to any future prerelease string.

## Verification
- Simulated `app.config.js` resolution: `0.10.0-test` → native `0.10.0`, full `0.10.0-test`.
- `tsc` clean, ESLint clean, all 572 tests pass.