### PR TITLE
fix(discover): contain Playlists for You card artwork

### DIFF
--- a/components/discover/DiscoverPlaylistCard.tsx
+++ b/components/discover/DiscoverPlaylistCard.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Image } from "expo-image";
 import { Ionicons } from "@expo/vector-icons";
-import { Card } from "@/components/ui/Card";
 import { Text } from "@/components/ui/Text";
 import { FlowArtwork } from "@/components/flow/FlowArtwork";
 import { useAuth } from "@/contexts/auth-context";
@@ -38,18 +37,18 @@ export function DiscoverPlaylistCard({ playlist, version, onPress }: Props) {
   const adopted = !!playlist.adoptedFlowId || !!playlist.adoptedPlaylistId;
 
   return (
-    <Card
+    <Pressable
       onPress={onPress}
-      bordered
-      pressedOpacity={0.85}
-      style={[styles.card, { width: CARD_WIDTH }]}
+      style={({ pressed }) => [
+        { width: CARD_WIDTH, opacity: pressed ? 0.7 : 1 },
+      ]}
     >
-      <View style={[styles.artwork, { borderColor: colors.separator }]}>
+      <View style={styles.artwork}>
         <FlowArtwork
           name={playlist.name}
           kind={playlist.type === "flow" ? "flow" : "playlist"}
           size={ART_SIZE}
-          radius={12}
+          radius={10}
         />
         {showArtwork ? (
           <Image
@@ -68,42 +67,42 @@ export function DiscoverPlaylistCard({ playlist, version, onPress }: Props) {
           </View>
         ) : null}
       </View>
-      <Text
-        variant="body"
-        numberOfLines={1}
-        style={[styles.title, { color: colors.text }]}
-      >
-        {playlist.name}
-      </Text>
-      {subtitle ? (
+      <View style={styles.info}>
         <Text
-          variant="caption"
-          numberOfLines={2}
-          style={{ color: colors.subtle }}
+          variant="body"
+          numberOfLines={1}
+          style={[styles.title, { color: colors.text }]}
         >
-          {subtitle}
+          {playlist.name}
         </Text>
-      ) : (
-        <Text variant="caption" style={{ color: colors.subtle }}>
-          {playlist.trackCount} tracks
-        </Text>
-      )}
-    </Card>
+        {subtitle ? (
+          <Text
+            variant="caption"
+            numberOfLines={2}
+            style={{ color: colors.subtle }}
+          >
+            {subtitle}
+          </Text>
+        ) : (
+          <Text variant="caption" style={{ color: colors.subtle }}>
+            {playlist.trackCount} tracks
+          </Text>
+        )}
+      </View>
+    </Pressable>
   );
 }
 
 const styles = StyleSheet.create({
-  card: {
-    padding: 8,
-    gap: 6,
-  },
   artwork: {
     width: ART_SIZE,
     height: ART_SIZE,
-    borderRadius: 12,
-    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
     overflow: "hidden",
-    marginBottom: 2,
+  },
+  info: {
+    paddingTop: 8,
+    gap: 2,
   },
   badge: {
     position: "absolute",


### PR DESCRIPTION
## Summary
Fixes #153 — artwork in the **Playlists for You** section was overflowing its card on Discover.

**Root cause:** `DiscoverPlaylistCard` wrapped content in a bordered `Card` with `padding: 8`, giving a 134px content box, but sized the artwork at the full `CARD_WIDTH` (150px) — so it bled 8px past each edge.

**Fix:** Replace the bordered/padded `Card` with a plain `Pressable` and let the artwork fill the full card width, matching the borderless edge-to-edge style of the release/album tiles.

## Changes
- Drop the `Card` wrapper (and its padding) in favor of a `Pressable`
- Remove the artwork hairline border to match release cards
- Move title/subtitle into an `info` container (`paddingTop: 8`, `gap: 2`)
- Align minor values to the release card: artwork `borderRadius` 12 → 10, press opacity 0.85 → 0.7
- Adopted-✓ badge and FlowArtwork/image-overlay logic unchanged

## Testing
- `tsc --noEmit` clean
- ESLint clean
- No tests reference the component directly